### PR TITLE
feat: criar site institucional e reorganizar blog

### DIFF
--- a/app/Http/Controllers/Front/ContactController.php
+++ b/app/Http/Controllers/Front/ContactController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Front;
+
+use App\Http\Controllers\Controller;
+
+class ContactController extends Controller
+{
+    public function index()
+    {
+        $contact = config('institutional.contact');
+        $services = config('institutional.services');
+
+        return view('front.contact', compact('contact', 'services'));
+    }
+}

--- a/app/Http/Controllers/Front/GalleryController.php
+++ b/app/Http/Controllers/Front/GalleryController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers\Front;
+
+use App\Http\Controllers\Controller;
+
+class GalleryController extends Controller
+{
+    public function index()
+    {
+        $images = config('institutional.gallery');
+
+        return view('front.gallery', compact('images'));
+    }
+}

--- a/app/Http/Controllers/Front/InstitutionalController.php
+++ b/app/Http/Controllers/Front/InstitutionalController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Front;
+
+use App\Http\Controllers\Controller;
+use App\Models\Post;
+
+class InstitutionalController extends Controller
+{
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $content;
+
+    public function __construct()
+    {
+        $this->content = config('institutional');
+    }
+
+    public function home()
+    {
+        $featuredPosts = Post::published()
+            ->with(['category', 'user'])
+            ->latest('created_at')
+            ->take(3)
+            ->get();
+
+        return view('front.home', [
+            'hero' => $this->content['hero'],
+            'about' => $this->content['about'],
+            'services' => array_slice($this->content['services'], 0, 3),
+            'projects' => $this->content['projects'],
+            'featuredPosts' => $featuredPosts,
+        ]);
+    }
+
+    public function about()
+    {
+        return view('front.about', [
+            'about' => $this->content['about'],
+            'projects' => $this->content['projects'],
+            'services' => $this->content['services'],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Front/ServiceController.php
+++ b/app/Http/Controllers/Front/ServiceController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers\Front;
+
+use App\Http\Controllers\Controller;
+
+class ServiceController extends Controller
+{
+    public function index()
+    {
+        $services = config('institutional.services');
+
+        return view('front.services', compact('services'));
+    }
+}

--- a/app/View/Components/BlogLayout.php
+++ b/app/View/Components/BlogLayout.php
@@ -12,14 +12,16 @@ use Illuminate\View\Component;
 class BlogLayout extends Component
 {
     public $title;
+    public bool $withSidebar;
     /**
      * Create a new component instance.
      *
      * @return void
      */
-    public function __construct($title = null)
+    public function __construct($title = null, bool $withSidebar = false)
     {
         $this->title = $title;
+        $this->withSidebar = $withSidebar;
     }
 
     /**
@@ -38,6 +40,15 @@ class BlogLayout extends Component
             $q->where('status', true);
         })->get();
 
-        return view('layouts.blog', compact('categories', 'top_users', 'setting', 'pages_nav', 'pages_footer', 'tags'));
+        return view('layouts.blog', [
+            'categories' => $categories,
+            'top_users' => $top_users,
+            'setting' => $setting,
+            'pages_nav' => $pages_nav,
+            'pages_footer' => $pages_footer,
+            'tags' => $tags,
+            'withSidebar' => $this->withSidebar,
+            'title' => $this->title,
+        ]);
     }
 }

--- a/config/institutional.php
+++ b/config/institutional.php
@@ -1,0 +1,81 @@
+<?php
+
+return [
+    'hero' => [
+        'title' => 'Soluções de engenharia e construção que transformam territórios',
+        'subtitle' => 'Projetos completos para infraestruturas públicas, empreendimentos privados e obras residenciais com excelência reconhecida.',
+        'cta' => [
+            'primary' => ['label' => 'Conheça os nossos serviços', 'route' => 'services'],
+            'secondary' => ['label' => 'Fale connosco', 'route' => 'contacts'],
+        ],
+        'stats' => [
+            ['value' => '25+', 'label' => 'Anos de experiência'],
+            ['value' => '180', 'label' => 'Projetos entregues'],
+            ['value' => '120', 'label' => 'Clientes satisfeitos'],
+        ],
+    ],
+    'about' => [
+        'mission' => 'Somos especialistas em obras de infraestruturas, reabilitação urbana e construção industrial, combinando tecnologia com equipas multidisciplinares para garantir resultados sustentáveis.',
+        'vision' => 'Criar espaços que inspiram confiança, segurança e prosperidade para comunidades e parceiros.',
+        'values' => [
+            ['title' => 'Compromisso', 'description' => 'Acompanhamos cada projeto de forma próxima, garantindo transparência e rigor em todas as fases.'],
+            ['title' => 'Inovação', 'description' => 'Investimos continuamente em metodologias e tecnologias que melhoram a eficiência das obras.'],
+            ['title' => 'Sustentabilidade', 'description' => 'Planeamos soluções que minimizam impactos ambientais e valorizam os recursos locais.'],
+        ],
+        'history' => 'Desde 1997, a Generaldo Torres atua em todo o território nacional com obras de referência para o setor público e privado. O nosso portefólio integra projetos de mobilidade urbana, reabilitação de património, construção de unidades industriais e soluções residenciais de alto desempenho.',
+    ],
+    'services' => [
+        [
+            'title' => 'Planeamento e Consultoria',
+            'description' => 'Estudos de viabilidade, licenciamento, modelação BIM e coordenação técnica para assegurar decisões estratégicas seguras.',
+            'icon' => 'clipboard-check',
+        ],
+        [
+            'title' => 'Construção Civil e Industrial',
+            'description' => 'Execução completa de obras estruturais, industriais e residenciais com equipas próprias e parceiros certificados.',
+            'icon' => 'building',
+        ],
+        [
+            'title' => 'Reabilitação e Manutenção',
+            'description' => 'Intervenções em património histórico, reforço estrutural e manutenção preventiva para prolongar a vida útil dos ativos.',
+            'icon' => 'tools',
+        ],
+        [
+            'title' => 'Infraestruturas e Obras Públicas',
+            'description' => 'Projetos de mobilidade, saneamento, energia e espaços públicos que impulsionam o desenvolvimento local.',
+            'icon' => 'road',
+        ],
+    ],
+    'projects' => [
+        [
+            'title' => 'Corredor Verde de Lisboa',
+            'description' => 'Rede de espaços verdes e ciclovias com sistemas de irrigação inteligente e iluminação eficiente.',
+            'image' => 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=60',
+        ],
+        [
+            'title' => 'Pavilhão Industrial Norte',
+            'description' => 'Construção modular de unidade fabril com foco em eficiência energética e segurança operacional.',
+            'image' => 'https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=900&q=60',
+        ],
+        [
+            'title' => 'Residencial Atlântico',
+            'description' => 'Condomínio residencial premium com soluções sustentáveis de climatização e reaproveitamento de água.',
+            'image' => 'https://images.unsplash.com/photo-1568605114967-8130f3a36994?auto=format&fit=crop&w=900&q=60',
+        ],
+    ],
+    'gallery' => [
+        ['image' => 'https://images.unsplash.com/photo-1505739679279-b9d5cc0b29d0?auto=format&fit=crop&w=900&q=60', 'caption' => 'Infraestruturas viárias'],
+        ['image' => 'https://images.unsplash.com/photo-1497366216548-37526070297c?auto=format&fit=crop&w=900&q=60', 'caption' => 'Obras industriais'],
+        ['image' => 'https://images.unsplash.com/photo-1504593811423-6dd665756598?auto=format&fit=crop&w=900&q=60', 'caption' => 'Reabilitação urbana'],
+        ['image' => 'https://images.unsplash.com/photo-1487956382158-bb926046304a?auto=format&fit=crop&w=900&q=60', 'caption' => 'Equipa multidisciplinar'],
+        ['image' => 'https://images.unsplash.com/photo-1518600506271-0b2cfdc23016?auto=format&fit=crop&w=900&q=60', 'caption' => 'Planeamento colaborativo'],
+        ['image' => 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=60', 'caption' => 'Projetos sustentáveis'],
+    ],
+    'contact' => [
+        'address' => 'Av. Eng. Duarte Pacheco, 1250-096 Lisboa',
+        'phone' => '+351 21 000 0000',
+        'email' => 'comercial@generaldo-torres.pt',
+        'schedule' => 'Segunda a Sexta, 9h às 18h',
+        'map' => 'https://maps.google.com/maps?q=lisboa&t=&z=13&ie=UTF8&iwloc=&output=embed',
+    ],
+];

--- a/resources/views/front/about.blade.php
+++ b/resources/views/front/about.blade.php
@@ -1,0 +1,75 @@
+<x-blog-layout>
+    @push('hero')
+        <section class="bg-gray-900 text-white">
+            <div class="container mx-auto px-6 py-16 lg:py-24">
+                <p class="uppercase tracking-widest text-sm text-gray-400">Quem somos</p>
+                <h1 class="text-4xl lg:text-5xl font-bold leading-tight max-w-3xl">Compromisso com a excelência em construção e engenharia</h1>
+                <p class="mt-6 text-lg text-gray-200 max-w-3xl">{{ $about['vision'] }}</p>
+            </div>
+        </section>
+    @endpush
+
+    <section class="py-16">
+        <div class="container mx-auto px-6 grid gap-12 lg:grid-cols-2 lg:items-start">
+            <div class="space-y-6">
+                <h2 class="text-3xl font-bold text-gray-900">A nossa missão</h2>
+                <p class="text-lg text-gray-600">{{ $about['mission'] }}</p>
+                <p class="text-gray-600">{{ $about['history'] }}</p>
+            </div>
+            <div class="space-y-6">
+                <h3 class="text-2xl font-semibold text-gray-900">Valores que guiam cada projeto</h3>
+                <div class="grid gap-6">
+                    @foreach ($about['values'] as $value)
+                        <div class="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+                            <h4 class="text-xl font-semibold text-blue-800">{{ $value['title'] }}</h4>
+                            <p class="text-gray-600 mt-2">{{ $value['description'] }}</p>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="py-16 bg-blue-50">
+        <div class="container mx-auto px-6">
+            <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6 mb-10">
+                <div>
+                    <span class="text-blue-700 font-semibold uppercase tracking-wider">Portefólio</span>
+                    <h2 class="text-3xl font-bold text-gray-900">Projetos que geram impacto positivo</h2>
+                </div>
+                <a href="{{ route('gallery') }}" class="text-blue-700 font-semibold hover:text-blue-900">Explorar galeria →</a>
+            </div>
+            <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+                @foreach ($projects as $project)
+                    <article class="bg-white rounded-2xl overflow-hidden shadow border border-blue-100">
+                        <img src="{{ $project['image'] }}" alt="{{ $project['title'] }}" class="h-48 w-full object-cover">
+                        <div class="p-6 space-y-2">
+                            <h3 class="text-xl font-semibold text-gray-900">{{ $project['title'] }}</h3>
+                            <p class="text-gray-600">{{ $project['description'] }}</p>
+                        </div>
+                    </article>
+                @endforeach
+            </div>
+        </div>
+    </section>
+
+    <section class="py-16">
+        <div class="container mx-auto px-6">
+            <div class="text-center max-w-3xl mx-auto space-y-6">
+                <h2 class="text-3xl font-bold text-gray-900">Especialização multidisciplinar</h2>
+                <p class="text-gray-600">Reunimos equipas altamente qualificadas que asseguram todas as fases de um projeto — do planeamento estratégico à execução e acompanhamento pós-obra.</p>
+            </div>
+            <div class="mt-12 grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+                @foreach ($services as $service)
+                    <div class="bg-white border border-gray-200 rounded-xl p-6 shadow-sm text-center">
+                        <div class="w-12 h-12 mx-auto rounded-full bg-blue-100 text-blue-700 flex items-center justify-center mb-4">
+                            <i class="fas fa-{{ $service['icon'] }} text-xl"></i>
+                        </div>
+                        <h3 class="text-lg font-semibold text-gray-900">{{ $service['title'] }}</h3>
+                        <p class="text-sm text-gray-600 mt-2">{{ $service['description'] }}</p>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </section>
+</x-blog-layout>

--- a/resources/views/front/category.blade.php
+++ b/resources/views/front/category.blade.php
@@ -1,48 +1,36 @@
-<x-blog-layout title="{{ $category_name }}">
-    <!-- Posts Section -->
-    <section class="w-full md:w-2/3 flex flex-col items-center px-3">
-
-
-        <!-- Article -->
-        @forelse ($posts as $post)
-            <article class="flex flex-col shadow my-4">
-                <a href="{{ route('post.show', $post->slug) }}" class="hover:opacity-75">
-                        <img src="{{ $post->image }}" width="1000" height="500">
-                </a>
-                <div class="bg-white flex flex-col justify-start p-6">
-                    <a href="{{ route('category.show', $post->category->slug) }} "
-                        class="text-blue-700 text-sm font-bold uppercase pb-4">{{ $post->category->name }}</a>
-                    <a href="{{ route('post.show', $post->slug) }}"
-                        class="text-3xl font-bold hover:text-gray-700 pb-4">{{ $post->title }}</a>
-                    <p href="#" class="text-sm pb-1">
-                        By <a href="#" class="font-semibold hover:text-gray-800">{{ $post->user->name }}</a>,
-                        Published on {{ $post->created_at }}
-                    </p>
-                    <p class="pb-3">{!! substr($post->content, 0, 100) !!} ...</p>
-                    {{-- <br /> --}}
-                    <a href="{{ route('post.show', $post->slug) }}"
-                        class="mt-px uppercase text-gray-800 font-bold hover:text-black">Continue Reading <i
-                            class="fas fa-arrow-right"></i></a>
-                </div>
-            </article>
-        @empty
-            <p>
-                No Posts has been added
-            </p>
-        @endforelse
-
-        <!-- Pagination -->
-        <div class="flex items-center py-8">
-            {{ $posts->links() }}
-
-            {{-- <a href="#"
-                class="h-10 w-10 bg-blue-800 hover:bg-blue-600 font-semibold text-white text-sm flex items-center justify-center">1</a>
-            <a href="#"
-                class="h-10 w-10 font-semibold text-gray-800 hover:bg-blue-600 hover:text-white text-sm flex items-center justify-center">2</a>
-            <a href="#"
-                class="h-10 w-10 font-semibold text-gray-800 hover:text-gray-900 text-sm flex items-center justify-center ml-3">Next
-                <i class="fas fa-arrow-right ml-2"></i></a> --}}
+<x-blog-layout :with-sidebar="true" title="{{ $category_name }}">
+    <div class="space-y-10">
+        <div class="space-y-3">
+            <h1 class="text-4xl font-bold text-gray-900">{{ $category_name }}</h1>
+            <p class="text-gray-600">Artigos associados a esta categoria.</p>
         </div>
 
-    </section>
+        <div class="space-y-8">
+            @forelse ($posts as $post)
+                <article class="bg-white rounded-2xl overflow-hidden shadow-sm border border-gray-100">
+                    <a href="{{ route('post.show', $post->slug) }}" class="block">
+                        <img src="{{ $post->image }}" alt="{{ $post->title }}" class="w-full h-56 object-cover">
+                    </a>
+                    <div class="p-6 space-y-4">
+                        <div class="flex items-center gap-3 text-xs uppercase tracking-wider text-blue-600 font-semibold">
+                            <span>{{ $category_name }}</span>
+                            <span class="text-gray-400">•</span>
+                            <span class="text-gray-500">{{ $post->created_at }}</span>
+                        </div>
+                        <h2 class="text-2xl font-semibold text-gray-900">
+                            <a href="{{ route('post.show', $post->slug) }}" class="hover:text-blue-700">{{ $post->title }}</a>
+                        </h2>
+                        <p class="text-gray-600">{!! \Illuminate\Support\Str::limit(strip_tags($post->content), 180) !!}</p>
+                        <a href="{{ route('post.show', $post->slug) }}" class="inline-flex items-center text-blue-700 font-semibold hover:text-blue-900">Ler artigo <i class="fas fa-arrow-right ml-2"></i></a>
+                    </div>
+                </article>
+            @empty
+                <p class="text-gray-600">Ainda não existem artigos nesta categoria.</p>
+            @endforelse
+        </div>
+
+        <div>
+            {{ $posts->links() }}
+        </div>
+    </div>
 </x-blog-layout>

--- a/resources/views/front/contact.blade.php
+++ b/resources/views/front/contact.blade.php
@@ -1,0 +1,75 @@
+<x-blog-layout>
+    @push('hero')
+        <section class="bg-gray-900 text-white">
+            <div class="container mx-auto px-6 py-16 lg:py-24">
+                <p class="uppercase tracking-widest text-sm text-gray-400">Contactos</p>
+                <h1 class="text-4xl lg:text-5xl font-bold leading-tight max-w-3xl">Estamos prontos para construir o seu próximo projeto</h1>
+                <p class="mt-6 text-lg text-gray-200 max-w-3xl">Fale com a nossa equipa comercial e descubra como podemos apoiar os seus objetivos.</p>
+            </div>
+        </section>
+    @endpush
+
+    <section class="py-16">
+        <div class="container mx-auto px-6 grid gap-12 lg:grid-cols-2">
+            <div class="space-y-6">
+                <h2 class="text-3xl font-bold text-gray-900">Informações de contacto</h2>
+                <div class="bg-white border border-gray-200 rounded-2xl p-8 shadow-sm space-y-6">
+                    <div>
+                        <p class="text-sm uppercase tracking-wider text-blue-700 font-semibold">Morada</p>
+                        <p class="text-lg text-gray-700">{{ $contact['address'] }}</p>
+                    </div>
+                    <div>
+                        <p class="text-sm uppercase tracking-wider text-blue-700 font-semibold">Telefone</p>
+                        <a href="tel:{{ preg_replace('/\s+/', '', $contact['phone']) }}" class="text-lg text-gray-700 hover:text-blue-700">{{ $contact['phone'] }}</a>
+                    </div>
+                    <div>
+                        <p class="text-sm uppercase tracking-wider text-blue-700 font-semibold">Email</p>
+                        <a href="mailto:{{ $contact['email'] }}" class="text-lg text-gray-700 hover:text-blue-700">{{ $contact['email'] }}</a>
+                    </div>
+                    <div>
+                        <p class="text-sm uppercase tracking-wider text-blue-700 font-semibold">Horário</p>
+                        <p class="text-lg text-gray-700">{{ $contact['schedule'] }}</p>
+                    </div>
+                </div>
+                <div class="bg-blue-50 border border-blue-100 rounded-2xl p-8 shadow-sm">
+                    <h3 class="text-2xl font-semibold text-gray-900 mb-4">Precisa de uma proposta?</h3>
+                    <p class="text-gray-600">Indique-nos o tipo de serviço pretendido e o prazo desejado. A nossa equipa responde em até 24 horas úteis.</p>
+                    <ul class="mt-4 space-y-2 text-gray-600">
+                        @foreach ($services as $service)
+                            <li class="flex items-start gap-2"><span class="text-blue-700 mt-1"><i class="fas fa-check-circle"></i></span>{{ $service['title'] }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            </div>
+            <div class="space-y-6">
+                <div class="bg-white border border-gray-200 rounded-2xl p-8 shadow-sm">
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-6">Envie-nos uma mensagem</h2>
+                    <form class="grid gap-4">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Nome</label>
+                            <input type="text" class="mt-1 w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500" placeholder="O seu nome">
+                        </div>
+                        <div class="grid md:grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700">Email</label>
+                                <input type="email" class="mt-1 w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500" placeholder="nome@empresa.com">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700">Telefone</label>
+                                <input type="text" class="mt-1 w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500" placeholder="(+351) 999 999 999">
+                            </div>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Mensagem</label>
+                            <textarea class="mt-1 w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500" rows="5" placeholder="Conte-nos sobre o seu projeto"></textarea>
+                        </div>
+                        <button type="button" class="mt-2 inline-flex justify-center px-6 py-3 bg-blue-700 text-white font-semibold rounded-lg hover:bg-blue-800 transition">Enviar mensagem</button>
+                    </form>
+                </div>
+                <div class="overflow-hidden rounded-2xl shadow-lg border border-gray-200">
+                    <iframe src="{{ $contact['map'] }}" width="100%" height="320" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+                </div>
+            </div>
+        </div>
+    </section>
+</x-blog-layout>

--- a/resources/views/front/gallery.blade.php
+++ b/resources/views/front/gallery.blade.php
@@ -1,0 +1,42 @@
+<x-blog-layout>
+    @push('hero')
+        <section class="bg-gradient-to-r from-blue-900 to-blue-700 text-white">
+            <div class="container mx-auto px-6 py-16 lg:py-24">
+                <p class="uppercase tracking-widest text-sm text-blue-200">Galeria</p>
+                <h1 class="text-4xl lg:text-5xl font-bold leading-tight max-w-3xl">Projetos em destaque que contam a nossa história</h1>
+                <p class="mt-6 text-lg text-blue-100 max-w-3xl">Conheça algumas das obras que consolidam a Generaldo Torres como referência em engenharia e construção.</p>
+            </div>
+        </section>
+    @endpush
+
+    <section class="py-16">
+        <div class="container mx-auto px-6">
+            <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+                @foreach ($images as $item)
+                    <figure class="group bg-white rounded-2xl overflow-hidden shadow-sm border border-gray-100">
+                        <img src="{{ $item['image'] }}" alt="{{ $item['caption'] }}" class="h-64 w-full object-cover transition duration-500 group-hover:scale-105">
+                        <figcaption class="p-6 text-gray-700 text-center font-medium">{{ $item['caption'] }}</figcaption>
+                    </figure>
+                @endforeach
+            </div>
+        </div>
+    </section>
+
+    <section class="py-16 bg-blue-50">
+        <div class="container mx-auto px-6 grid gap-10 lg:grid-cols-2 lg:items-center">
+            <div class="space-y-6">
+                <h2 class="text-3xl font-bold text-gray-900">Rigor em todas as fases</h2>
+                <p class="text-gray-600">As nossas equipas acompanham a execução no terreno com metodologias ágeis e ferramentas digitais que garantem o cumprimento de prazos e padrões de qualidade.</p>
+                <a href="{{ route('services') }}" class="inline-flex items-center text-blue-700 font-semibold hover:text-blue-900">Conhecer serviços →</a>
+            </div>
+            <div class="grid gap-6 sm:grid-cols-2">
+                @foreach (array_slice($images, 0, 4) as $item)
+                    <div class="bg-white border border-gray-200 rounded-xl p-4 shadow-sm">
+                        <img src="{{ $item['image'] }}" alt="{{ $item['caption'] }}" class="h-32 w-full object-cover rounded-lg">
+                        <p class="mt-3 text-sm text-gray-600">{{ $item['caption'] }}</p>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </section>
+</x-blog-layout>

--- a/resources/views/front/home.blade.php
+++ b/resources/views/front/home.blade.php
@@ -1,0 +1,109 @@
+<x-blog-layout>
+    @push('hero')
+        <section class="bg-blue-900 text-white">
+            <div class="container mx-auto px-6 py-16 lg:py-24 flex flex-col lg:flex-row items-start gap-12">
+                <div class="lg:w-1/2 space-y-6">
+                    <p class="uppercase tracking-widest text-sm text-blue-200">Generaldo Torres</p>
+                    <h1 class="text-4xl lg:text-5xl font-bold leading-tight">{{ $hero['title'] }}</h1>
+                    <p class="text-lg text-blue-100">{{ $hero['subtitle'] }}</p>
+                    <div class="flex flex-col sm:flex-row gap-4">
+                        <a href="{{ route($hero['cta']['primary']['route']) }}" class="px-6 py-3 bg-white text-blue-900 font-semibold rounded shadow hover:bg-blue-100 transition">{{ $hero['cta']['primary']['label'] }}</a>
+                        <a href="{{ route($hero['cta']['secondary']['route']) }}" class="px-6 py-3 border border-white text-white font-semibold rounded hover:bg-white hover:text-blue-900 transition">{{ $hero['cta']['secondary']['label'] }}</a>
+                    </div>
+                </div>
+                <div class="lg:w-1/2 grid grid-cols-1 sm:grid-cols-3 gap-6">
+                    @foreach ($hero['stats'] as $stat)
+                        <div class="bg-blue-800/60 backdrop-blur rounded-lg p-6 shadow-lg">
+                            <p class="text-3xl font-bold">{{ $stat['value'] }}</p>
+                            <p class="text-sm uppercase tracking-wide text-blue-200">{{ $stat['label'] }}</p>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </section>
+    @endpush
+
+    <section class="py-16">
+        <div class="container mx-auto px-6 grid gap-12 lg:grid-cols-2 lg:items-center">
+            <div class="space-y-6">
+                <span class="text-blue-700 font-semibold uppercase tracking-wider">Sobre nós</span>
+                <h2 class="text-3xl lg:text-4xl font-bold text-gray-900">Construímos confiança em cada projeto</h2>
+                <p class="text-lg text-gray-600">{{ $about['mission'] }}</p>
+                <p class="text-gray-600">{{ $about['history'] }}</p>
+                <div class="grid sm:grid-cols-3 gap-6">
+                    @foreach ($about['values'] as $value)
+                        <div class="bg-white shadow rounded-lg p-6 border-t-4 border-blue-700">
+                            <h3 class="font-semibold text-lg text-gray-900">{{ $value['title'] }}</h3>
+                            <p class="text-sm text-gray-600 mt-2">{{ $value['description'] }}</p>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+            <div class="grid gap-6">
+                @foreach ($projects as $project)
+                    <article class="bg-white shadow-lg rounded-2xl overflow-hidden">
+                        <img src="{{ $project['image'] }}" alt="{{ $project['title'] }}" class="h-48 w-full object-cover">
+                        <div class="p-6 space-y-2">
+                            <h3 class="text-xl font-semibold text-gray-900">{{ $project['title'] }}</h3>
+                            <p class="text-gray-600">{{ $project['description'] }}</p>
+                        </div>
+                    </article>
+                @endforeach
+            </div>
+        </div>
+    </section>
+
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6">
+            <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6 mb-10">
+                <div>
+                    <span class="text-blue-700 font-semibold uppercase tracking-wider">Competências</span>
+                    <h2 class="text-3xl font-bold text-gray-900">Serviços estratégicos para cada desafio</h2>
+                </div>
+                <a href="{{ route('services') }}" class="text-blue-700 font-semibold hover:text-blue-900">Ver todos os serviços →</a>
+            </div>
+            <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+                @foreach ($services as $service)
+                    <div class="bg-white rounded-xl shadow-sm p-8 border border-gray-100">
+                        <div class="w-12 h-12 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center mb-6">
+                            <i class="fas fa-{{ $service['icon'] }} text-xl"></i>
+                        </div>
+                        <h3 class="text-xl font-semibold text-gray-900">{{ $service['title'] }}</h3>
+                        <p class="text-gray-600 mt-3">{{ $service['description'] }}</p>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </section>
+
+    <section class="py-16">
+        <div class="container mx-auto px-6">
+            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6 mb-10">
+                <div>
+                    <span class="text-blue-700 font-semibold uppercase tracking-wider">Atualidade</span>
+                    <h2 class="text-3xl font-bold text-gray-900">Destaques do nosso blog</h2>
+                </div>
+                <a href="{{ route('blog.index') }}" class="text-blue-700 font-semibold hover:text-blue-900">Aceder ao blog →</a>
+            </div>
+            <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+                @forelse ($featuredPosts as $post)
+                    <article class="bg-white rounded-2xl overflow-hidden shadow-sm border border-gray-100 flex flex-col">
+                        <a href="{{ route('post.show', $post->slug) }}" class="block">
+                            <img src="{{ $post->image }}" alt="{{ $post->title }}" class="h-48 w-full object-cover">
+                        </a>
+                        <div class="p-6 flex-1 flex flex-col">
+                            <a href="{{ route('category.show', $post->category->slug) }}" class="text-xs uppercase tracking-widest text-blue-600 font-semibold">{{ $post->category->name }}</a>
+                            <h3 class="mt-3 text-xl font-semibold text-gray-900">
+                                <a href="{{ route('post.show', $post->slug) }}" class="hover:text-blue-700">{{ $post->title }}</a>
+                            </h3>
+                            <p class="mt-4 text-sm text-gray-600">{{ \Illuminate\Support\Str::limit(strip_tags($post->content), 120) }}</p>
+                            <div class="mt-6 text-sm text-gray-500">Por {{ $post->user->name }}</div>
+                        </div>
+                    </article>
+                @empty
+                    <p class="text-gray-600">Ainda não existem publicações ativas.</p>
+                @endforelse
+            </div>
+        </div>
+    </section>
+</x-blog-layout>

--- a/resources/views/front/index.blade.php
+++ b/resources/views/front/index.blade.php
@@ -1,37 +1,39 @@
-<x-blog-layout>
-     <!-- Posts Section -->
- <section class="w-full md:w-2/3 flex flex-col items-center px-3">
+<x-blog-layout :with-sidebar="true" title="Blog">
+    <div class="space-y-10">
+        <div class="space-y-4">
+            <h1 class="text-4xl font-bold text-gray-900">Blog</h1>
+            <p class="text-gray-600">Exploramos tendências de engenharia, histórias de projetos e bastidores da Generaldo Torres.</p>
+        </div>
 
+        <div class="space-y-8">
+            @forelse ($posts as $post)
+                <article class="bg-white rounded-2xl overflow-hidden shadow-sm border border-gray-100">
+                    <a href="{{ route('post.show', $post->slug) }}" class="block">
+                        <img src="{{ $post->image }}" alt="{{ $post->title }}" class="w-full h-64 object-cover">
+                    </a>
+                    <div class="p-6 space-y-4">
+                        <div class="flex items-center gap-3 text-xs uppercase tracking-wider text-blue-600 font-semibold">
+                            <a href="{{ route('category.show', $post->category->slug) }}" class="hover:text-blue-800">{{ $post->category->name }}</a>
+                            <span class="text-gray-400">•</span>
+                            <span class="text-gray-500">{{ $post->created_at }}</span>
+                        </div>
+                        <h2 class="text-2xl font-semibold text-gray-900">
+                            <a href="{{ route('post.show', $post->slug) }}" class="hover:text-blue-700">{{ $post->title }}</a>
+                        </h2>
+                        <p class="text-gray-600">{!! \Illuminate\Support\Str::limit(strip_tags($post->content), 200) !!}</p>
+                        <div class="flex items-center justify-between pt-4 border-t border-gray-100 text-sm text-gray-500">
+                            <span>Por {{ $post->user->name }}</span>
+                            <a href="{{ route('post.show', $post->slug) }}" class="inline-flex items-center text-blue-700 font-semibold hover:text-blue-900">Ler artigo completo <i class="fas fa-arrow-right ml-2"></i></a>
+                        </div>
+                    </div>
+                </article>
+            @empty
+                <p class="text-gray-600">Ainda não existem artigos publicados.</p>
+            @endforelse
+        </div>
 
-        <!-- Article -->
-        @forelse ($posts as $post)
-        <article class="flex flex-col shadow my-4">
-            <a href="{{ route('post.show', $post->slug ) }}" class="hover:opacity-75">
-            <img src="{{ $post->image }}" width="1000" height="500">
-            </a>
-            <div class="bg-white flex flex-col justify-start p-6">
-                <a href="{{ route('category.show', $post->category->slug) }} " class="text-blue-700 text-sm font-bold uppercase pb-4">{{ $post->category->name }}</a>
-                <a href="{{ route('post.show', $post->slug ) }}" class="text-3xl font-bold hover:text-gray-700 pb-4">{{ $post->title }}</a>
-                <p href="#" class="text-sm pb-1">
-                    By <a href="#" class="font-semibold hover:text-gray-800">{{ $post->user->name }}</a>, Published on {{ $post->created_at }}
-                </p>
-                <p class="pb-3">{!! substr($post->content, 0, 100) !!} ...</p>
-                {{-- <br /> --}}
-                <a href="{{ route('post.show', $post->slug) }}" class="mt-px uppercase text-gray-800 font-bold hover:text-black">Continue Reading <i class="fas fa-arrow-right"></i></a>
-            </div>
-        </article>
-        @empty
-        <p>
-        No Posts has been added
-        </p>
-        @endforelse
-
-    <!-- Pagination -->
-    <div class="flex items-center py-8">
-
-        {{ $posts->links() }}
-
+        <div>
+            {{ $posts->links() }}
+        </div>
     </div>
-
-</section>
 </x-blog-layout>

--- a/resources/views/front/page.blade.php
+++ b/resources/views/front/page.blade.php
@@ -1,18 +1,8 @@
 <x-blog-layout title="{{ $page->name }}">
-
-    {{-- <div class="container mx-auto flex flex-wrap py-6 w-full"> --}}
-
-        <!-- Post Section -->
-        <section class="w-full flex flex-col items-center px-3">
-
-            <article class="flex flex-col w-full shadow my-4">
-                <!-- Article Image -->
-                <div class="bg-white flex flex-col justify-start p-6 w-">
-                    <div class="text-3xl font-bold pb-4 text-center">{{ $page->name }}</div>
-                    {!! $page->content !!}
-                </div>
-            </article>
-
-        </section>
-
+    <article class="bg-white rounded-3xl shadow-sm border border-gray-100 p-8 space-y-6">
+        <h1 class="text-4xl font-bold text-gray-900 text-center">{{ $page->name }}</h1>
+        <div class="prose max-w-none prose-blue mx-auto">
+            {!! $page->content !!}
+        </div>
+    </article>
 </x-blog-layout>

--- a/resources/views/front/post.blade.php
+++ b/resources/views/front/post.blade.php
@@ -1,134 +1,103 @@
-<x-blog-layout title="{{ $post_title }}">
-
-    <div class="container mx-auto flex flex-wrap py-6">
-
-        <!-- Post Section -->
-        <section class="w-full md:w-2/3 flex flex-col items-center px-3">
-
-
-            <article class="flex flex-col shadow my-4">
-                <!-- Article Image -->
-                    <img src="{{ $post->image }}" width="1000" height="500">
-                <div class="bg-white flex flex-col justify-start p-6">
-                    <a href="{{ route('category.show', $post->category->slug) }}"
-                        class="text-blue-700 text-sm font-bold uppercase pb-4">{{ $post->category->name }}</a>
-                    <div class="text-3xl font-bold pb-4">{{ $post->title }}</div>
-                    <p href="#" class="text-sm pb-8">
-                        By <a href="#" class="font-semibold hover:text-blue-800">{{ $post->user->name }}</a>,
-                        Published on {{ $post->created_at }}
-                    </p>
-                    {!! $post->content !!}
-                </div>
-            </article>
-            {{-- author --}}
-            <div class="w-full flex flex-col text-center md:text-left md:flex-row shadow bg-white mt-10 mb-10 p-6">
-                <div class="w-full md:w-1/5 flex justify-center md:justify-start pb-4">
-                        <img src="{{ $post->user->avatar }}"
-                            class="rounded-full shadow h-32 w-32">
-                </div>
-                <div class="flex-1 flex flex-col justify-center md:justify-start">
-                    <p class="font-semibold text-2xl">{{ $post->user->name }}</p>
-                    <p class="pt-2">{{ $post->user->bio }}</p>
-                    <div
-                        class="flex items-center justify-center md:justify-start text-2xl no-underline text-blue-800 pt-4">
-                        <a class="" href="{{ $post->user->url_fb }}">
-                            <i class="fab fa-facebook"></i>
-                        </a>
-                        <a class="pl-4" href="{{ $post->user->url_insta }}">
-                            <i class="fab fa-instagram"></i>
-                        </a>
-                        <a class="pl-4" href="{{ $post->user->url_twitter }}">
-                            <i class="fab fa-twitter"></i>
-                        </a>
-                        <a class="pl-4" href="{{ $post->user->url_linkedin }}">
-                            <i class="fab fa-linkedin"></i>
-                        </a>
-                    </div>
-                </div>
+<x-blog-layout :with-sidebar="true" title="{{ $post_title }}">
+    <article class="bg-white rounded-3xl overflow-hidden shadow-sm border border-gray-100">
+        <img src="{{ $post->image }}" alt="{{ $post->title }}" class="w-full h-96 object-cover">
+        <div class="p-8 space-y-6">
+            <div class="flex flex-wrap items-center gap-4 text-sm text-gray-500">
+                <a href="{{ route('category.show', $post->category->slug) }}" class="inline-flex items-center px-3 py-1 bg-blue-50 text-blue-700 rounded-full text-xs font-semibold uppercase tracking-wider">{{ $post->category->name }}</a>
+                <span>{{ $post->created_at }}</span>
             </div>
-            {{--  --}}
-            {{-- comment section --}}
-            @auth
+            <h1 class="text-4xl font-bold text-gray-900">{{ $post->title }}</h1>
+            <div class="prose max-w-none prose-blue">
+                {!! $post->content !!}
+            </div>
+        </div>
+    </article>
+
+    <section class="bg-white rounded-3xl shadow-sm border border-gray-100 p-8 flex flex-col md:flex-row gap-6">
+        <div class="md:w-32 md:flex-shrink-0">
+            <img src="{{ $post->user->avatar }}" alt="{{ $post->user->name }}" class="w-24 h-24 md:w-32 md:h-32 rounded-full object-cover">
+        </div>
+        <div class="flex-1 space-y-3">
+            <h2 class="text-2xl font-semibold text-gray-900">{{ $post->user->name }}</h2>
+            <p class="text-gray-600">{{ $post->user->bio }}</p>
+            <div class="flex items-center gap-4 text-xl text-blue-700">
+                <a href="{{ $post->user->url_fb }}" class="hover:text-blue-900"><i class="fab fa-facebook"></i></a>
+                <a href="{{ $post->user->url_insta }}" class="hover:text-blue-900"><i class="fab fa-instagram"></i></a>
+                <a href="{{ $post->user->url_twitter }}" class="hover:text-blue-900"><i class="fab fa-twitter"></i></a>
+                <a href="{{ $post->user->url_linkedin }}" class="hover:text-blue-900"><i class="fab fa-linkedin"></i></a>
+            </div>
+        </div>
+    </section>
+
+    <section class="space-y-8">
+        @auth
+            <div class="bg-white rounded-3xl shadow-sm border border-gray-100 p-8">
+                <h2 class="text-2xl font-semibold text-gray-900 mb-4">Deixe o seu comentário</h2>
                 @if ($errors->any())
-                    <div role="alert">
-                        <div class="bg-red-500 text-white font-bold rounded-t px-4 py-2 mx-4">
-                            Validation Errors
-                        </div>
-                        <div class="border border-t-0 border-red-400 rounded-b bg-red-100 px-4 py-3 text-red-700 mx-4">
-                            <ul>
-                                @foreach ($errors->all() as $error)
-                                    <li>{{ $error }}</li>
-                                @endforeach
-                            </ul>
-                        </div>
+                    <div class="mb-4 rounded-lg border border-red-200 bg-red-50 text-red-700 p-4">
+                        <p class="font-semibold">Ocorreram alguns erros:</p>
+                        <ul class="list-disc list-inside text-sm mt-2 space-y-1">
+                            @foreach ($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
                     </div>
                 @endif
-                <div class="w-full flex text-center md:text-left md:flex-col shadow bg-white mt-10 mb-10 p-6">
-                    <p class="font-semibold text-2xl pb-2">Comment As: {{ auth()->user()->name }}</p>
-                    <form method="POST" action="{{ route('post.comment', $post) }}">
-                        @csrf
-                        <textarea class="w-full p-2.5 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg" name="body" cols="30" rows="10" placeholder="Write your comment here .."></textarea>
-                        <button type="submit"
-                            class="mt-2 py-2 px-4 bg-green-500 hover:bg-green-700 hover:text-white">Submit
-                            Comment</button>
-                    </form>
+                <form method="POST" action="{{ route('post.comment', $post) }}" class="space-y-4">
+                    @csrf
+                    <textarea name="body" rows="5" class="w-full rounded-xl border-gray-300 focus:border-blue-500 focus:ring-blue-500" placeholder="Escreva a sua mensagem"></textarea>
+                    <button type="submit" class="inline-flex items-center px-6 py-3 bg-blue-700 text-white font-semibold rounded-full hover:bg-blue-800">Publicar comentário</button>
+                </form>
+            </div>
+        @else
+            <div class="bg-blue-50 border border-blue-100 rounded-3xl p-8 text-center">
+                <h2 class="text-2xl font-semibold text-blue-900">Quer participar na conversa?</h2>
+                <p class="mt-3 text-blue-800">Faça login para partilhar a sua opinião sobre este conteúdo.</p>
+                <div class="mt-6 flex flex-wrap justify-center gap-4">
+                    <a href="{{ route('login') }}" class="px-6 py-3 bg-blue-700 text-white font-semibold rounded-full hover:bg-blue-800">Iniciar sessão</a>
+                    <a href="{{ route('register') }}" class="px-6 py-3 border border-blue-700 text-blue-700 font-semibold rounded-full hover:bg-blue-700 hover:text-white">Criar conta</a>
                 </div>
-            @else
-                <div class="w-full flex text-center md:text-left md:flex-col shadow bg-red-400 mt-10 mb-10 p-6">
-                    <p class="font-semibold text-white text-2xl pb-2"> Signin to able to comment !</p>
-                </div>
-            @endauth
+            </div>
+        @endauth
 
-            <div class="w-full flex text-center md:text-left md:flex-col shadow bg-white mt-10 mb-10 p-6">
-                <p class="font-semibold text-2xl pb-2">Comments</p>
-                {{-- user comments --}}
-                @foreach ($comments as $comment)
-                    <div class="w-full flex text-center md:text-left md:flex-col shadow bg-white mt-10 mb-10 p-6">
-                        <p class="font-semibold text-xl pb-2">{{ $comment->user->name }}</p>
-                        <p class="font-semibold text-gray-600 text-lg pb-2">{{ $comment->body }}</p>
+        <div class="bg-white rounded-3xl shadow-sm border border-gray-100 p-8 space-y-6">
+            <h2 class="text-2xl font-semibold text-gray-900">Comentários</h2>
+            @forelse ($comments as $comment)
+                <div class="border-t border-gray-100 pt-6">
+                    <div class="flex items-center justify-between">
+                        <p class="font-semibold text-gray-900">{{ $comment->user->name }}</p>
                         @can('delete', $comment)
-                            <form method="POST" action="{{ route('comment.destroy', $comment->id) }}"
-                                onsubmit="return confirm('Are you sure?')">
+                            <form method="POST" action="{{ route('comment.destroy', $comment->id) }}" onsubmit="return confirm('Tem a certeza que pretende eliminar este comentário?')">
                                 @csrf
                                 @method('DELETE')
-                                <button class="py-2 px-4 bg-red-500 hover:bg-red-700 hover:text-white">Delete</button>
+                                <button class="text-sm text-red-600 hover:text-red-800">Remover</button>
                             </form>
                         @endcan
                     </div>
-                @endforeach
-                {{--  --}}
-            </div>
+                    <p class="mt-2 text-gray-600">{{ $comment->body }}</p>
+                </div>
+            @empty
+                <p class="text-gray-600">Ainda não existem comentários. Seja o primeiro a partilhar a sua opinião.</p>
+            @endforelse
+        </div>
+    </section>
 
-            <div class="w-full flex pt-6">
-                @if (isset($post->previous))
-                    <a href="{{ route('post.show', $post->previous->slug) }}"
-                        class="w-1/2 bg-white shadow hover:shadow-md text-left p-6">
-                        <p class="text-lg text-blue-800 font-bold flex items-center"><i
-                                class="fas fa-arrow-left pr-1"></i> Previous</p>
-                        <p class="pt-2">{{ $post->previous->title }}</p>
-                    </a>
-                @else
-                    <div class="w-1/2 bg-white shadow hover:shadow-md text-left p-6">
-                        <p class="pt-2">This is the first post</p>
-                    </div>
-                @endif
-
-                @if (isset($post->next))
-                    <a href="{{ route('post.show', $post->next->slug) }}"
-                        class="w-1/2 bg-white shadow hover:shadow-md text-right p-6">
-                        <p class="text-lg text-blue-800 font-bold flex items-center justify-end">Next <i
-                                class="fas fa-arrow-right pl-1"></i></p>
-                        <p class="pt-2">{{ $post->next->title }}</p>
-                    </a>
-                @else
-                    <div class="w-1/2 bg-white shadow hover:shadow-md text-right p-6">
-                        <p class="pt-2">This is the last post</p>
-                    </div>
-                @endif
-            </div>
-
-
-
-        </section>
-
+    <div class="grid gap-6 md:grid-cols-2">
+        <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-6">
+            @if (isset($post->previous))
+                <span class="text-xs uppercase tracking-wider text-gray-500">Artigo anterior</span>
+                <a href="{{ route('post.show', $post->previous->slug) }}" class="mt-2 block text-lg font-semibold text-blue-700 hover:text-blue-900">{{ $post->previous->title }}</a>
+            @else
+                <p class="text-gray-500">Este é o primeiro artigo da categoria.</p>
+            @endif
+        </div>
+        <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-6 text-right">
+            @if (isset($post->next))
+                <span class="text-xs uppercase tracking-wider text-gray-500">Próximo artigo</span>
+                <a href="{{ route('post.show', $post->next->slug) }}" class="mt-2 block text-lg font-semibold text-blue-700 hover:text-blue-900">{{ $post->next->title }}</a>
+            @else
+                <p class="text-gray-500">Este é o último artigo publicado.</p>
+            @endif
+        </div>
+    </div>
 </x-blog-layout>

--- a/resources/views/front/services.blade.php
+++ b/resources/views/front/services.blade.php
@@ -1,0 +1,52 @@
+<x-blog-layout>
+    @push('hero')
+        <section class="bg-blue-900 text-white">
+            <div class="container mx-auto px-6 py-16 lg:py-24">
+                <p class="uppercase tracking-widest text-sm text-blue-200">O que fazemos</p>
+                <h1 class="text-4xl lg:text-5xl font-bold leading-tight max-w-3xl">Serviços integrados para construir o futuro com qualidade</h1>
+                <p class="mt-6 text-lg text-blue-100 max-w-3xl">Da consultoria estratégica à execução em obra, entregamos soluções completas adaptadas a cada desafio.</p>
+            </div>
+        </section>
+    @endpush
+
+    <section class="py-16">
+        <div class="container mx-auto px-6">
+            <div class="grid gap-10 md:grid-cols-2">
+                @foreach ($services as $service)
+                    <div class="bg-white border border-gray-200 rounded-2xl p-8 shadow-sm">
+                        <div class="flex items-center gap-4 mb-4">
+                            <div class="w-14 h-14 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center">
+                                <i class="fas fa-{{ $service['icon'] }} text-2xl"></i>
+                            </div>
+                            <h2 class="text-2xl font-semibold text-gray-900">{{ $service['title'] }}</h2>
+                        </div>
+                        <p class="text-gray-600">{{ $service['description'] }}</p>
+                        <div class="mt-6 pt-6 border-t border-gray-100 text-sm text-gray-500">
+                            <p>Planeamento detalhado, cronogramas transparentes e equipas multidisciplinares garantem que cada serviço responda às expectativas dos nossos clientes.</p>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </section>
+
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6 grid gap-10 lg:grid-cols-2 lg:items-center">
+            <div class="space-y-6">
+                <span class="text-blue-700 font-semibold uppercase tracking-wider">Metodologia</span>
+                <h2 class="text-3xl font-bold text-gray-900">Processos orientados a resultados</h2>
+                <ul class="space-y-4 text-gray-600">
+                    <li class="flex gap-3"><span class="text-blue-700 font-semibold">1.</span>Diagnóstico técnico e definição de objetivos.</li>
+                    <li class="flex gap-3"><span class="text-blue-700 font-semibold">2.</span>Planeamento colaborativo com equipas e stakeholders.</li>
+                    <li class="flex gap-3"><span class="text-blue-700 font-semibold">3.</span>Execução com monitorização contínua de qualidade e segurança.</li>
+                    <li class="flex gap-3"><span class="text-blue-700 font-semibold">4.</span>Entrega assistida e planos de manutenção.</li>
+                </ul>
+            </div>
+            <div class="bg-white border border-gray-200 rounded-2xl p-8 shadow-sm space-y-4">
+                <h3 class="text-2xl font-semibold text-gray-900">Porque escolher a Generaldo Torres?</h3>
+                <p class="text-gray-600">Integramos equipas especializadas, tecnologia e uma rede sólida de parceiros que garante execução eficiente e cumprimento rigoroso de prazos.</p>
+                <a href="{{ route('contacts') }}" class="inline-flex items-center text-blue-700 font-semibold hover:text-blue-900">Solicitar uma proposta →</a>
+            </div>
+        </div>
+    </section>
+</x-blog-layout>

--- a/resources/views/front/tag.blade.php
+++ b/resources/views/front/tag.blade.php
@@ -1,48 +1,36 @@
-<x-blog-layout title="{{ $tag }}">
-    <!-- Posts Section -->
-    <section class="w-full md:w-2/3 flex flex-col items-center px-3">
-
-
-        <!-- Article -->
-        @forelse ($tags as $post)
-            <article class="flex flex-col shadow my-4">
-                <a href="{{ route('post.show', $post->slug ) }}" class="hover:opacity-75">
-                    <img src="{{ $post->image }}" width="1000" height="500">
-                </a>
-                <div class="bg-white flex flex-col justify-start p-6">
-                    <a href="{{ route('category.show', $post->category->slug) }} "
-                        class="text-blue-700 text-sm font-bold uppercase pb-4">{{ $post->category->name }}</a>
-                    <a href="{{ route('post.show', $post->slug) }}"
-                        class="text-3xl font-bold hover:text-gray-700 pb-4">{{ $post->title }}</a>
-                    <p href="#" class="text-sm pb-1">
-                        By <a href="#" class="font-semibold hover:text-gray-800">{{ $post->user->name }}</a>,
-                        Published on {{ $post->created_at }}
-                    </p>
-                    <p class="pb-3">{!! substr($post->content, 0, 100) !!} ...</p>
-                    {{-- <br /> --}}
-                    <a href="{{ route('post.show', $post->slug) }}"
-                        class="mt-px uppercase text-gray-800 font-bold hover:text-black">Continue Reading <i
-                            class="fas fa-arrow-right"></i></a>
-                </div>
-            </article>
-        @empty
-            <p>
-                No Posts has been added
-            </p>
-        @endforelse
-
-        <!-- Pagination -->
-        <div class="flex items-center py-8">
-            {{ $tags->links() }}
-
-            {{-- <a href="#"
-                class="h-10 w-10 bg-blue-800 hover:bg-blue-600 font-semibold text-white text-sm flex items-center justify-center">1</a>
-            <a href="#"
-                class="h-10 w-10 font-semibold text-gray-800 hover:bg-blue-600 hover:text-white text-sm flex items-center justify-center">2</a>
-            <a href="#"
-                class="h-10 w-10 font-semibold text-gray-800 hover:text-gray-900 text-sm flex items-center justify-center ml-3">Next
-                <i class="fas fa-arrow-right ml-2"></i></a> --}}
+<x-blog-layout :with-sidebar="true" title="{{ $tag }}">
+    <div class="space-y-10">
+        <div class="space-y-3">
+            <h1 class="text-4xl font-bold text-gray-900">Etiqueta: {{ $tag }}</h1>
+            <p class="text-gray-600">Conteúdos identificados com esta palavra-chave.</p>
         </div>
 
-    </section>
+        <div class="space-y-8">
+            @forelse ($tags as $post)
+                <article class="bg-white rounded-2xl overflow-hidden shadow-sm border border-gray-100">
+                    <a href="{{ route('post.show', $post->slug) }}" class="block">
+                        <img src="{{ $post->image }}" alt="{{ $post->title }}" class="w-full h-56 object-cover">
+                    </a>
+                    <div class="p-6 space-y-4">
+                        <div class="flex items-center gap-3 text-xs uppercase tracking-wider text-blue-600 font-semibold">
+                            <a href="{{ route('category.show', $post->category->slug) }}" class="hover:text-blue-800">{{ $post->category->name }}</a>
+                            <span class="text-gray-400">•</span>
+                            <span class="text-gray-500">{{ $post->created_at }}</span>
+                        </div>
+                        <h2 class="text-2xl font-semibold text-gray-900">
+                            <a href="{{ route('post.show', $post->slug) }}" class="hover:text-blue-700">{{ $post->title }}</a>
+                        </h2>
+                        <p class="text-gray-600">{!! \Illuminate\Support\Str::limit(strip_tags($post->content), 180) !!}</p>
+                        <a href="{{ route('post.show', $post->slug) }}" class="inline-flex items-center text-blue-700 font-semibold hover:text-blue-900">Ler artigo <i class="fas fa-arrow-right ml-2"></i></a>
+                    </div>
+                </article>
+            @empty
+                <p class="text-gray-600">Ainda não existem conteúdos associados a esta etiqueta.</p>
+            @endforelse
+        </div>
+
+        <div>
+            {{ $tags->links() }}
+        </div>
+    </div>
 </x-blog-layout>

--- a/resources/views/layouts/blog.blade.php
+++ b/resources/views/layouts/blog.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt">
 
 <head>
     <meta charset="UTF-8">
@@ -7,204 +7,192 @@
     <title>
         @isset($title)
             {{ ucfirst($title) }} -
-        @endisset {{ config('app.name') }}
+        @endisset{{ config('app.name') }}
     </title>
-    <!-- Tailwind -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js" integrity="sha256-KzZiKy0DWYsnwMF+X1DvQngQ2/FxF7MF3Ff72XcpuPs=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js" defer></script>
     <style>
-        @import url('https://fonts.googleapis.com/css?family=Karla:400,700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
-        .font-family-karla {
-            font-family: karla;
+        body {
+            font-family: 'Inter', sans-serif;
         }
     </style>
-
-    <!-- AlpineJS -->
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js" defer></script>
-    <!-- Font Awesome -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"
-        integrity="sha256-KzZiKy0DWYsnwMF+X1DvQngQ2/FxF7MF3Ff72XcpuPs=" crossorigin="anonymous"></script>
 </head>
 
-<body class="bg-white font-family-karla">
-    @if (Session::has('message'))
-        <div class="flex items-center bg-green-500 text-white text-sm font-bold px-4 py-3" role="alert">
-            <svg class="fill-current w-4 h-4 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                <path
-                    d="M12.432 0c1.34 0 2.01.912 2.01 1.957 0 1.305-1.164 2.512-2.679 2.512-1.269 0-2.009-.75-1.974-1.99C9.789 1.436 10.67 0 12.432 0zM8.309 20c-1.058 0-1.833-.652-1.093-3.524l1.214-5.092c.211-.814.246-1.141 0-1.141-.317 0-1.689.562-2.502 1.117l-.528-.88c2.572-2.186 5.531-3.467 6.801-3.467 1.057 0 1.233 1.273.705 3.23l-1.391 5.352c-.246.945-.141 1.271.106 1.271.317 0 1.357-.392 2.379-1.207l.6.814C12.098 19.02 9.365 20 8.309 20z" />
-            </svg>
-            <p>{{ Session::get('message') }}.</p>
+<body class="bg-gray-50 text-gray-900 antialiased">
+    @if (Session::has('message') || Session::has('error'))
+        <div class="container mx-auto px-6 mt-4">
+            <div class="rounded-xl px-6 py-4 shadow-md {{ Session::has('message') ? 'bg-green-50 text-green-800 border border-green-200' : 'bg-red-50 text-red-800 border border-red-200' }}">
+                {{ Session::get('message') ?? Session::get('error') }}
+            </div>
         </div>
-    @elseif (Session::has('error'))
-        {
-        <div class="flex items-center bg-red-500 text-white text-sm font-bold px-4 py-3" role="alert">
-            <svg class="fill-current w-4 h-4 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                <path
-                    d="M12.432 0c1.34 0 2.01.912 2.01 1.957 0 1.305-1.164 2.512-2.679 2.512-1.269 0-2.009-.75-1.974-1.99C9.789 1.436 10.67 0 12.432 0zM8.309 20c-1.058 0-1.833-.652-1.093-3.524l1.214-5.092c.211-.814.246-1.141 0-1.141-.317 0-1.689.562-2.502 1.117l-.528-.88c2.572-2.186 5.531-3.467 6.801-3.467 1.057 0 1.233 1.273.705 3.23l-1.391 5.352c-.246.945-.141 1.271.106 1.271.317 0 1.357-.392 2.379-1.207l.6.814C12.098 19.02 9.365 20 8.309 20z" />
-            </svg>
-            <p>{{ Session::get('error') }}.</p>
-        </div>
-        }
     @endif
-    <!-- Top Bar Nav -->
-    <nav class="w-full py-4 bg-blue-800 shadow">
-        <div class="w-full container mx-auto flex flex-wrap items-center justify-between">
 
-            <nav>
-                <ul class="flex items-center justify-between font-bold text-sm text-white uppercase no-underline">
+    <div class="min-h-screen flex flex-col">
+        <header class="bg-white shadow-sm border-b border-gray-100" x-data="{ open: false }">
+            <div class="container mx-auto px-6 py-5 flex items-center justify-between gap-6">
+                <div class="flex items-center gap-6">
+                    <a href="{{ route('webhome') }}" class="text-2xl font-semibold text-blue-900">{{ $setting->site_name }}</a>
+                    <p class="hidden md:block text-sm text-gray-500 max-w-md">{{ $setting->description }}</p>
+                </div>
+                <button class="md:hidden text-blue-900" @click="open = !open">
+                    <i :class="open ? 'fas fa-times' : 'fas fa-bars'"></i>
+                </button>
+                <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-gray-700">
+                    <a href="{{ route('webhome') }}" class="hover:text-blue-700">Início</a>
+                    <a href="{{ route('about') }}" class="hover:text-blue-700">Sobre nós</a>
+                    <a href="{{ route('services') }}" class="hover:text-blue-700">Serviços</a>
+                    <a href="{{ route('gallery') }}" class="hover:text-blue-700">Galeria</a>
+                    <a href="{{ route('blog.index') }}" class="hover:text-blue-700">Blog</a>
+                    <a href="{{ route('contacts') }}" class="hover:text-blue-700">Contactos</a>
                     @foreach ($pages_nav as $page)
-                        <li><a class="hover:text-gray-200 hover:underline px-4"
-                                href="{{ route('page.show', $page->slug) }}">{{ $page->name }}</a></li>
+                        <a href="{{ route('page.show', $page->slug) }}" class="hover:text-blue-700">{{ $page->name }}</a>
                     @endforeach
-
-                    @auth
-                        <form method="POST" action="{{ route('logout') }}">
-                            @csrf
-                            <button class="py-2 px-4 bg-red-500 hover:bg-red-700">LogOut</button>
-                        </form>
-                    @else
-                        <li><a class="py-2 px-4 mr-2 bg-gray-500 hover:bg-gray-700"
-                                href="{{ route('register') }}">Register</a>
-                        <li><a class="py-2 px-4 bg-green-500 hover:bg-green-700" href="{{ route('login') }}">Login</a>
-                        @endauth
-
-                </ul>
-            </nav>
-
-            <div class="flex items-center text-lg no-underline text-white pr-6">
-                <a class="" href="{{ $setting->url_fb }}">
-                    <i class="fab fa-facebook"></i>
-                </a>
-                <a class="pl-6" href="{{ $setting->url_insta }}">
-                    <i class="fab fa-instagram"></i>
-                </a>
-                <a class="pl-6" href="{{ $setting->url_twitter }}">
-                    <i class="fab fa-twitter"></i>
-                </a>
-                <a class="pl-6" href="{{ $setting->url_linkedin }}">
-                    <i class="fab fa-linkedin"></i>
-                </a>
-            </div>
-        </div>
-
-    </nav>
-
-    <!-- Text Header -->
-    <header class="w-full container mx-auto">
-        <div class="flex flex-col items-center py-12">
-            <a class="font-bold text-gray-800 uppercase hover:text-gray-700 text-5xl" href="{{ route('webhome') }}">
-                {{ $setting->site_name }}
-            </a>
-            <p class="text-lg text-gray-600">
-                {{ $setting->description }}
-            </p>
-        </div>
-    </header>
-
-    <!-- Topic Nav -->
-    <nav class="w-full py-4 border-t border-b bg-gray-100" x-data="{ open: false }">
-        <div class="block sm:hidden">
-            <a href="#"
-                class="block md:hidden text-base font-bold uppercase text-center flex justify-center items-center"
-                @click="open = !open">
-                Topics <i :class="open ? 'fa-chevron-down' : 'fa-chevron-up'" class="fas ml-2"></i>
-            </a>
-        </div>
-        <div :class="open ? 'block' : 'hidden'" class="w-full flex-grow sm:flex sm:items-center sm:w-auto">
-            <div
-                class="w-full container mx-auto flex flex-col sm:flex-row items-center justify-center text-sm font-bold uppercase mt-0 px-6 py-2">
-                <a href="{{ route('webhome') }}" class="hover:bg-gray-400 rounded py-2 px-4 mx-2">Home</a>
-                @forelse ($categories as $category)
-                    <a href="{{ route('category.show', $category->slug) }}"
-                        class="hover:bg-gray-400 rounded py-2 px-4 mx-2">{{ $category->name }}</a>
-                @empty
-                    No Categories !
-                @endforelse
-            </div>
-        </div>
-    </nav>
-
-
-    <div class="container mx-auto flex flex-wrap py-6">
-
-        {{ $slot }}
-
-        <!-- Sidebar Section -->
-        @if (!request()->routeIs('page.show'))
-            <aside class="w-full md:w-1/3 flex flex-col items-center px-3">
-
-                <div class="w-full bg-white shadow flex flex-col my-4 p-6">
-                    <p class="text-xl font-semibold pb-5">About Us</p>
-                    <p class="pb-2">{{ $setting->about }}</p>
-                    {{-- <a href="#"
-                    class="w-full bg-blue-800 text-white font-bold text-sm uppercase rounded hover:bg-blue-700 flex items-center justify-center px-2 py-3 mt-4">
-                    Get to know us
-                </a> --}}
+                </nav>
+                <div class="hidden md:flex items-center gap-4 text-blue-900 text-xl">
+                    <a href="{{ $setting->url_fb }}" aria-label="Facebook" class="hover:text-blue-700"><i class="fab fa-facebook"></i></a>
+                    <a href="{{ $setting->url_insta }}" aria-label="Instagram" class="hover:text-blue-700"><i class="fab fa-instagram"></i></a>
+                    <a href="{{ $setting->url_twitter }}" aria-label="Twitter" class="hover:text-blue-700"><i class="fab fa-twitter"></i></a>
+                    <a href="{{ $setting->url_linkedin }}" aria-label="LinkedIn" class="hover:text-blue-700"><i class="fab fa-linkedin"></i></a>
                 </div>
-
-                <div class="w-full bg-white shadow flex flex-col my-4 p-6">
-                    <p class="text-xl font-semibold pb-5">Tags</p>
-                    <div class="flex flex-wrap">
-
-                        @foreach ($tags as $tag)
-                            <a href="{{ route('tag.show', $tag->name) }}"
-                                class="flex justify-center items-center m-1 font-medium py-1 px-2 bg-white rounded-full text-blue-700 bg-blue-100 border border-blue-300 ">
-                                <div class="p-1.5 text-xs font-normal leading-none max-w-full flex-initial">
-                                    {{ $tag->name }}</div>
-                            </a>
+            </div>
+            <div class="md:hidden" x-show="open" x-transition>
+                <nav class="bg-white border-t border-gray-100 shadow-inner">
+                    <div class="px-6 py-4 space-y-3 text-sm font-medium text-gray-700">
+                        <a href="{{ route('webhome') }}" class="block">Início</a>
+                        <a href="{{ route('about') }}" class="block">Sobre nós</a>
+                        <a href="{{ route('services') }}" class="block">Serviços</a>
+                        <a href="{{ route('gallery') }}" class="block">Galeria</a>
+                        <a href="{{ route('blog.index') }}" class="block">Blog</a>
+                        <a href="{{ route('contacts') }}" class="block">Contactos</a>
+                        @foreach ($pages_nav as $page)
+                            <a href="{{ route('page.show', $page->slug) }}" class="block">{{ $page->name }}</a>
                         @endforeach
-
+                        <div class="flex flex-wrap gap-4 pt-4 text-lg text-blue-900">
+                            <a href="{{ $setting->url_fb }}" aria-label="Facebook" class="hover:text-blue-700"><i class="fab fa-facebook"></i></a>
+                            <a href="{{ $setting->url_insta }}" aria-label="Instagram" class="hover:text-blue-700"><i class="fab fa-instagram"></i></a>
+                            <a href="{{ $setting->url_twitter }}" aria-label="Twitter" class="hover:text-blue-700"><i class="fab fa-twitter"></i></a>
+                            <a href="{{ $setting->url_linkedin }}" aria-label="LinkedIn" class="hover:text-blue-700"><i class="fab fa-linkedin"></i></a>
+                        </div>
                     </div>
+                </nav>
+            </div>
+        </header>
+
+        @auth
+            <div class="bg-blue-900 text-white">
+                <div class="container mx-auto px-6 py-2 flex items-center justify-end gap-3 text-sm">
+                    <span>Bem-vindo, {{ auth()->user()->name }}</span>
+                    <form method="POST" action="{{ route('logout') }}" class="inline">
+                        @csrf
+                        <button class="px-3 py-1 bg-white text-blue-900 font-semibold rounded-full hover:bg-blue-100">Terminar sessão</button>
+                    </form>
                 </div>
+            </div>
+        @else
+            <div class="bg-blue-900 text-white">
+                <div class="container mx-auto px-6 py-2 flex items-center justify-end gap-3 text-sm">
+                    <a href="{{ route('login') }}" class="px-3 py-1 bg-white text-blue-900 font-semibold rounded-full hover:bg-blue-100">Área reservada</a>
+                    <a href="{{ route('register') }}" class="px-3 py-1 border border-white rounded-full hover:bg-white hover:text-blue-900">Criar conta</a>
+                </div>
+            </div>
+        @endauth
 
-                <div class="w-full bg-white shadow flex flex-col my-4 p-6">
-                    <p class="text-xl font-semibold pb-5">Top 5 Writers</p>
-                    {{--  --}}
-                    <div class="content flex justify-between py-2 w-full">
-                        <div class="px-2 justify-between">
-                            Name
+        @stack('hero')
 
+        <main class="flex-1">
+            @if ($withSidebar)
+                <div class="container mx-auto px-6 py-16">
+                    <div class="grid gap-12 lg:grid-cols-[2fr,1fr]">
+                        <div class="space-y-10">
+                            {{ $slot }}
                         </div>
-                        <div class="justify-between">
-                            Posts Count
-                        </div>
-                    </div>
-                    @forelse ($top_users as $top)
-                        <div class="my-1.5 py-3	px-4 flex justify-center rounded-lg shadow-lg bg-white w-full ">
-                                <img class="w-10 h-10 rounded-full" src="{{ $top->avatar }}"
-                                    alt="">
-                            <div class="content flex justify-between py-2 w-full">
-                                <div class="px-2 justify-between">
-                                    {{ $top->name }}
-                                </div>
-                                <div class="justify-between">
-                                    {{ $top->posts_count }}
+                        <aside class="space-y-8">
+                            <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-8">
+                                <h2 class="text-xl font-semibold text-gray-900 mb-4">Sobre a Generaldo Torres</h2>
+                                <p class="text-gray-600">{{ $setting->about }}</p>
+                            </div>
+                            <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-8">
+                                <h2 class="text-xl font-semibold text-gray-900 mb-4">Categorias</h2>
+                                <div class="flex flex-wrap gap-2">
+                                    @foreach ($categories as $category)
+                                        <a href="{{ route('category.show', $category->slug) }}" class="px-3 py-1 rounded-full bg-blue-50 text-blue-700 text-sm font-medium hover:bg-blue-100">{{ $category->name }}</a>
+                                    @endforeach
                                 </div>
                             </div>
-                        </div>
-                    @empty
-                        No Members !
-                    @endforelse
+                            <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-8">
+                                <h2 class="text-xl font-semibold text-gray-900 mb-4">Etiquetas</h2>
+                                <div class="flex flex-wrap gap-2">
+                                    @foreach ($tags as $tag)
+                                        <a href="{{ route('tag.show', $tag->name) }}" class="px-3 py-1 rounded-full border border-blue-200 text-blue-700 text-sm hover:bg-blue-50">{{ $tag->name }}</a>
+                                    @endforeach
+                                </div>
+                            </div>
+                            <div class="bg-white rounded-2xl border border-gray-100 shadow-sm p-8">
+                                <h2 class="text-xl font-semibold text-gray-900 mb-4">Top autores</h2>
+                                <ul class="space-y-4">
+                                    @forelse ($top_users as $top)
+                                        <li class="flex items-center gap-4">
+                                            <img src="{{ $top->avatar }}" alt="{{ $top->name }}" class="w-12 h-12 rounded-full object-cover">
+                                            <div>
+                                                <p class="font-semibold text-gray-900">{{ $top->name }}</p>
+                                                <p class="text-sm text-gray-500">{{ $top->posts_count }} artigos publicados</p>
+                                            </div>
+                                        </li>
+                                    @empty
+                                        <li class="text-gray-500">Ainda não existem autores destacados.</li>
+                                    @endforelse
+                                </ul>
+                            </div>
+                        </aside>
+                    </div>
                 </div>
+            @else
+                <div class="container mx-auto px-6 py-16">
+                    {{ $slot }}
+                </div>
+            @endif
+        </main>
 
-            </aside>
-        @endif
-
-
-    </div>
-
-    <footer class="w-full border-t bg-white pb-12">
-
-        <div class="w-full container mx-auto flex flex-col items-center">
-            <div class="flex flex-col md:flex-row text-center md:text-left md:justify-between py-6">
-                @foreach ($pages_footer as $page)
-                    <a href="{{ route('page.show', $page->slug) }}" class="uppercase px-3 hover:text-blue-700">{{ $page->name }}</a>
-                @endforeach
+        <footer class="bg-gray-900 text-gray-300">
+            <div class="container mx-auto px-6 py-12 grid gap-10 md:grid-cols-3">
+                <div>
+                    <h3 class="text-white text-lg font-semibold">{{ $setting->site_name }}</h3>
+                    <p class="mt-3 text-sm text-gray-400">{{ $setting->description }}</p>
+                    <div class="flex items-center gap-4 mt-6 text-xl">
+                        <a href="{{ $setting->url_fb }}" class="hover:text-white"><i class="fab fa-facebook"></i></a>
+                        <a href="{{ $setting->url_insta }}" class="hover:text-white"><i class="fab fa-instagram"></i></a>
+                        <a href="{{ $setting->url_twitter }}" class="hover:text-white"><i class="fab fa-twitter"></i></a>
+                        <a href="{{ $setting->url_linkedin }}" class="hover:text-white"><i class="fab fa-linkedin"></i></a>
+                    </div>
+                </div>
+                <div>
+                    <h4 class="text-white text-lg font-semibold">Mapa do site</h4>
+                    <ul class="mt-4 space-y-2 text-sm">
+                        <li><a href="{{ route('webhome') }}" class="hover:text-white">Início</a></li>
+                        <li><a href="{{ route('about') }}" class="hover:text-white">Sobre nós</a></li>
+                        <li><a href="{{ route('services') }}" class="hover:text-white">Serviços</a></li>
+                        <li><a href="{{ route('gallery') }}" class="hover:text-white">Galeria</a></li>
+                        <li><a href="{{ route('blog.index') }}" class="hover:text-white">Blog</a></li>
+                        <li><a href="{{ route('contacts') }}" class="hover:text-white">Contactos</a></li>
+                        @foreach ($pages_footer as $page)
+                            <li><a href="{{ route('page.show', $page->slug) }}" class="hover:text-white">{{ $page->name }}</a></li>
+                        @endforeach
+                    </ul>
+                </div>
+                <div>
+                    <h4 class="text-white text-lg font-semibold">Notícias em destaque</h4>
+                    <p class="mt-4 text-sm text-gray-400">Acompanhe as novidades da Generaldo Torres e receba conteúdos sobre construção e engenharia.</p>
+                    <a href="{{ route('blog.index') }}" class="mt-6 inline-flex items-center px-4 py-2 bg-blue-700 text-white text-sm font-semibold rounded-full hover:bg-blue-600">Visitar o blog</a>
+                </div>
             </div>
-            <div class="uppercase pb-6">&copy; {{ $setting->copy_rights }}</div>
-        </div>
-    </footer>
-
+            <div class="border-t border-gray-800">
+                <div class="container mx-auto px-6 py-4 text-center text-xs text-gray-500">&copy; {{ $setting->copy_rights }}</div>
+            </div>
+        </footer>
+    </div>
 </body>
 
 </html>

--- a/routes/front.php
+++ b/routes/front.php
@@ -1,16 +1,25 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\Front\HomeController;
-use App\Http\Controllers\Front\ProfileController;
-use App\Http\Controllers\Front\PostController as FrontPostController;
 use App\Http\Controllers\Front\CategoryController as FrontCategoryController;
 use App\Http\Controllers\Front\CommentController;
+use App\Http\Controllers\Front\ContactController;
+use App\Http\Controllers\Front\GalleryController;
+use App\Http\Controllers\Front\HomeController;
+use App\Http\Controllers\Front\InstitutionalController;
 use App\Http\Controllers\Front\PageController as FrontPageController;
+use App\Http\Controllers\Front\PostController as FrontPostController;
+use App\Http\Controllers\Front\ProfileController;
+use App\Http\Controllers\Front\ServiceController;
 use App\Http\Controllers\Front\TagController as FrontTagController;
 
 // FrontEnd Routes [Public routes]
-Route::get('/', HomeController::class)->name('webhome');
+Route::get('/', [InstitutionalController::class, 'home'])->name('webhome');
+Route::get('/sobre-nos', [InstitutionalController::class, 'about'])->name('about');
+Route::get('/servicos', [ServiceController::class, 'index'])->name('services');
+Route::get('/galeria', [GalleryController::class, 'index'])->name('gallery');
+Route::get('/contactos', [ContactController::class, 'index'])->name('contacts');
+Route::get('/blog', HomeController::class)->name('blog.index');
 Route::post('/post/comment/{post}', [CommentController::class,'makeComment'])->name('post.comment');
 Route::resource('/comment', CommentController::class, ['only' => ['destroy']]);
 Route::get('/post/{slug}', [FrontPostController::class, 'getPostBySlug'])->name('post.show');


### PR DESCRIPTION
## Summary
- atualizar as rotas públicas para separar o site institucional do blog
- criar controladores e configuração de conteúdo para alimentar as novas páginas
- produzir novo layout institucional e templates Blade para home, serviços, galeria, contactos e ajustar páginas do blog

## Testing
- `composer install --no-interaction` *(falha: dependências exigem PHP <= 8.3)*
- `php artisan test` *(falha: vendor/autoload.php ausente devido à falha anterior)*

------
https://chatgpt.com/codex/tasks/task_e_68caf30f68bc83209ce413dd0bd7e0cb