### PR TITLE
Add services and gallery admin management

### DIFF
--- a/app/Http/Controllers/Admin/GalleryController.php
+++ b/app/Http/Controllers/Admin/GalleryController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\GalleryRequest;
+use App\Models\Gallery;
+use App\Models\Service;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class GalleryController extends Controller
+{
+    public function __construct()
+    {
+        $this->authorizeResource(Gallery::class, 'gallery');
+    }
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): View
+    {
+        $galleries = Gallery::withService()->latest()->paginate(15);
+
+        return view('admin.gallery.index', compact('galleries'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create(): View
+    {
+        $services = Service::ordered()->pluck('title', 'id');
+
+        return view('admin.gallery.create', compact('services'));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(GalleryRequest $request): RedirectResponse
+    {
+        $data = $request->validated();
+
+        if ($request->hasFile('image')) {
+            $data['image_path'] = $request->file('image')->store('images/galleries');
+        }
+
+        unset($data['image']);
+
+        Gallery::create($data);
+
+        return to_route('admin.gallery.index')->with('message', trans('admin.gallery_created'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Gallery $gallery): View
+    {
+        $services = Service::ordered()->pluck('title', 'id');
+
+        return view('admin.gallery.edit', compact('gallery', 'services'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(GalleryRequest $request, Gallery $gallery): RedirectResponse
+    {
+        $data = $request->validated();
+
+        if ($request->hasFile('image')) {
+            $data['image_path'] = $request->file('image')->store('images/galleries');
+        }
+
+        unset($data['image']);
+
+        $gallery->update($data);
+
+        return to_route('admin.gallery.index')->with('message', trans('admin.gallery_updated'));
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Gallery $gallery): RedirectResponse
+    {
+        $gallery->delete();
+
+        return to_route('admin.gallery.index')->with('message', trans('admin.gallery_deleted'));
+    }
+}

--- a/app/Http/Controllers/Admin/ServiceController.php
+++ b/app/Http/Controllers/Admin/ServiceController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\ServiceRequest;
+use App\Models\Service;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class ServiceController extends Controller
+{
+    public function __construct()
+    {
+        $this->authorizeResource(Service::class, 'service');
+    }
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): View
+    {
+        $services = Service::withCount('galleries')->ordered()->paginate(15);
+
+        return view('admin.service.index', compact('services'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create(): View
+    {
+        return view('admin.service.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(ServiceRequest $request): RedirectResponse
+    {
+        $data = $request->validated();
+        $data['order'] = $data['order'] ?? 0;
+
+        Service::create($data);
+
+        return to_route('admin.service.index')->with('message', trans('admin.service_created'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Service $service): View
+    {
+        return view('admin.service.edit', compact('service'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(ServiceRequest $request, Service $service): RedirectResponse
+    {
+        $data = $request->validated();
+        $data['order'] = $data['order'] ?? 0;
+
+        $service->update($data);
+
+        return to_route('admin.service.index')->with('message', trans('admin.service_updated'));
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Service $service): RedirectResponse
+    {
+        $service->delete();
+
+        return to_route('admin.service.index')->with('message', trans('admin.service_deleted'));
+    }
+}

--- a/app/Http/Requests/Admin/GalleryRequest.php
+++ b/app/Http/Requests/Admin/GalleryRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class GalleryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'service_id' => ['nullable', Rule::exists('services', 'id')],
+            'image' => [
+                $this->isMethod('post') ? 'required' : 'nullable',
+                'image',
+                'mimes:jpg,jpeg,png,webp,avif',
+                'max:5120',
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/ServiceRequest.php
+++ b/app/Http/Requests/Admin/ServiceRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class ServiceRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $serviceId = $this->route('service')?->id;
+
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'icon' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'slug' => [
+                'nullable',
+                'string',
+                'max:255',
+                Rule::unique('services', 'slug')->ignore($serviceId),
+            ],
+            'order' => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Models/Gallery.php
+++ b/app/Models/Gallery.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+
+class Gallery extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'title',
+        'image_path',
+        'description',
+        'service_id',
+    ];
+
+    /**
+     * @var array<int, string>
+     */
+    protected $appends = [
+        'image_url',
+    ];
+
+    /**
+     * Get the related service.
+     */
+    public function service()
+    {
+        return $this->belongsTo(Service::class);
+    }
+
+    /**
+     * Scope a query to eager load the service relation.
+     */
+    public function scopeWithService(Builder $query): Builder
+    {
+        return $query->with('service:id,title');
+    }
+
+    /**
+     * Accessor for the public image url.
+     */
+    public function getImageUrlAttribute(): string
+    {
+        return $this->image_path ? asset("storage/{$this->image_path}") : asset('import/assets/post-pic-dummy.png');
+    }
+
+    /**
+     * Boot model events.
+     */
+    protected static function booted(): void
+    {
+        static::updating(function (Gallery $gallery): void {
+            if ($gallery->isDirty('image_path') && !is_null($gallery->getRawOriginal('image_path'))) {
+                Storage::delete($gallery->getRawOriginal('image_path'));
+            }
+        });
+
+        static::deleting(function (Gallery $gallery): void {
+            if (!is_null($gallery->getRawOriginal('image_path'))) {
+                Storage::delete($gallery->getRawOriginal('image_path'));
+            }
+        });
+    }
+}

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class Service extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'title',
+        'icon',
+        'description',
+        'slug',
+        'order',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'order' => 'integer',
+    ];
+
+    /**
+     * Boot the model.
+     */
+    protected static function booted(): void
+    {
+        static::creating(function (Service $service): void {
+            $service->slug = static::generateSlug($service);
+        });
+
+        static::updating(function (Service $service): void {
+            $service->slug = static::generateSlug($service, $service->id);
+        });
+    }
+
+    /**
+     * Define the relationship with the gallery images.
+     */
+    public function galleries()
+    {
+        return $this->hasMany(Gallery::class);
+    }
+
+    /**
+     * Scope a query to order services by the order column.
+     */
+    public function scopeOrdered(Builder $query): Builder
+    {
+        return $query->orderBy('order')->orderBy('title');
+    }
+
+    /**
+     * Scope a query to filter a specific slug.
+     */
+    public function scopeWithSlug(Builder $query, string $slug): Builder
+    {
+        return $query->where('slug', $slug);
+    }
+
+    /**
+     * Generate a unique slug for the service.
+     */
+    protected static function generateSlug(Service $service, ?int $ignoreId = null): string
+    {
+        $slugSource = $service->slug ?: $service->title;
+        $baseSlug = Str::slug($slugSource);
+        $slug = $baseSlug;
+        $counter = 1;
+
+        while (static::query()
+            ->when($ignoreId, fn (Builder $query) => $query->whereKeyNot($ignoreId))
+            ->where('slug', $slug)
+            ->exists()) {
+            $slug = $baseSlug . '-' . $counter;
+            $counter++;
+        }
+
+        return $slug;
+    }
+}

--- a/app/Policies/GalleryPolicy.php
+++ b/app/Policies/GalleryPolicy.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Gallery;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class GalleryPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->getRole('Admin');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Gallery $gallery): bool
+    {
+        return $user->getRole('Admin');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->getRole('Admin');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Gallery $gallery): bool
+    {
+        return $user->getRole('Admin');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Gallery $gallery): bool
+    {
+        return $user->getRole('Admin');
+    }
+}

--- a/app/Policies/ServicePolicy.php
+++ b/app/Policies/ServicePolicy.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Service;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ServicePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->getRole('Admin');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Service $service): bool
+    {
+        return $user->getRole('Admin');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->getRole('Admin');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Service $service): bool
+    {
+        return $user->getRole('Admin');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Service $service): bool
+    {
+        return $user->getRole('Admin');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,7 +4,11 @@ namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
 
+use App\Models\Gallery;
+use App\Models\Service;
 use App\Models\User;
+use App\Policies\GalleryPolicy;
+use App\Policies\ServicePolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 
@@ -16,7 +20,8 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        // 'App\Models\Model' => 'App\Policies\ModelPolicy',
+        Service::class => ServicePolicy::class,
+        Gallery::class => GalleryPolicy::class,
     ];
 
     /**

--- a/database/migrations/2025_09_17_174549_create_services_table.php
+++ b/database/migrations/2025_09_17_174549_create_services_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('services', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('icon')->nullable();
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->unsignedInteger('order')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('services');
+    }
+};

--- a/database/migrations/2025_09_17_174555_create_galleries_table.php
+++ b/database/migrations/2025_09_17_174555_create_galleries_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('galleries', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('image_path');
+            $table->text('description')->nullable();
+            $table->foreignId('service_id')->nullable()->constrained()->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('galleries');
+    }
+};

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -16,4 +16,10 @@ return [
     'tag_deleted' => 'Tag Deleted !',
     'user_deleted' => 'User Deleted !',
     'role_updated' => 'Role to user Updated !',
+    'service_created' => 'Service Created !',
+    'service_updated' => 'Service Updated !',
+    'service_deleted' => 'Service Deleted !',
+    'gallery_created' => 'Gallery image Created !',
+    'gallery_updated' => 'Gallery image Updated !',
+    'gallery_deleted' => 'Gallery image Deleted !',
 ];

--- a/resources/views/admin/gallery/create.blade.php
+++ b/resources/views/admin/gallery/create.blade.php
@@ -1,0 +1,45 @@
+<x-admin-layout>
+
+    <div class="w-full h-screen overflow-x-hidden border-t flex flex-col">
+        <main class="w-full flex-grow p-6">
+            <h1 class="w-full text-3xl text-black pb-6">Add Gallery Image</h1>
+
+            <div class="w-full mt-12">
+                <p class="text-xl pb-3 flex items-center">
+                    <i class="fas fa-list mr-3"></i> Image Details
+                </p>
+                <form method="POST" action="{{ route('admin.gallery.store') }}" enctype="multipart/form-data">
+                    @csrf
+                    <div class="grid gap-6 mb-6 md:grid-cols-2">
+                        <div class="mb-1">
+                            <label for="title" class="block mb-2 text-sm font-medium text-gray-900">Title</label>
+                            <input type="text" id="title" name="title" value="{{ old('title') }}" required
+                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        </div>
+                        <div class="mb-1">
+                            <label for="service_id" class="block mb-2 text-sm font-medium text-gray-900">Service</label>
+                            <select id="service_id" name="service_id"
+                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                <option value="">No service</option>
+                                @foreach ($services as $id => $name)
+                                    <option value="{{ $id }}" @selected(old('service_id') == $id)>{{ $name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                    </div>
+                    <div class="mb-4">
+                        <label for="description" class="block mb-2 text-sm font-medium text-gray-900">Description</label>
+                        <textarea id="description" name="description" rows="4"
+                            class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">{{ old('description') }}</textarea>
+                    </div>
+                    <div class="mb-4">
+                        <label for="image" class="block mb-2 text-sm font-medium text-gray-900">Image</label>
+                        <input type="file" id="image" name="image" accept="image/*" required
+                            class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                    </div>
+                    <button class="px-4 py-1 text-white font-light tracking-wider bg-blue-600 rounded">Save Image</button>
+                </form>
+            </div>
+        </main>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/gallery/edit.blade.php
+++ b/resources/views/admin/gallery/edit.blade.php
@@ -1,0 +1,48 @@
+<x-admin-layout>
+
+    <div class="w-full h-screen overflow-x-hidden border-t flex flex-col">
+        <main class="w-full flex-grow p-6">
+            <h1 class="w-full text-3xl text-black pb-6">Edit Gallery Image</h1>
+
+            <div class="w-full mt-12">
+                <p class="text-xl pb-3 flex items-center">
+                    <i class="fas fa-list mr-3"></i> Image Details
+                </p>
+                <form method="POST" action="{{ route('admin.gallery.update', $gallery->id) }}" enctype="multipart/form-data">
+                    @csrf
+                    @method('PUT')
+                    <div class="grid gap-6 mb-6 md:grid-cols-2">
+                        <div class="mb-1">
+                            <label for="title" class="block mb-2 text-sm font-medium text-gray-900">Title</label>
+                            <input type="text" id="title" name="title" value="{{ old('title', $gallery->title) }}" required
+                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        </div>
+                        <div class="mb-1">
+                            <label for="service_id" class="block mb-2 text-sm font-medium text-gray-900">Service</label>
+                            <select id="service_id" name="service_id"
+                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                <option value="">No service</option>
+                                @foreach ($services as $id => $name)
+                                    <option value="{{ $id }}" @selected(old('service_id', $gallery->service_id) == $id)>{{ $name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                    </div>
+                    <div class="mb-4">
+                        <label for="description" class="block mb-2 text-sm font-medium text-gray-900">Description</label>
+                        <textarea id="description" name="description" rows="4"
+                            class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">{{ old('description', $gallery->description) }}</textarea>
+                    </div>
+                    <div class="mb-4">
+                        <label class="block mb-2 text-sm font-medium text-gray-900">Current Image</label>
+                        <img src="{{ $gallery->image_url }}" alt="{{ $gallery->title }}" class="h-24 rounded mb-4">
+                        <label for="image" class="block mb-2 text-sm font-medium text-gray-900">Replace Image</label>
+                        <input type="file" id="image" name="image" accept="image/*"
+                            class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                    </div>
+                    <button class="px-4 py-1 text-white font-light tracking-wider bg-blue-600 rounded">Update Image</button>
+                </form>
+            </div>
+        </main>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/gallery/index.blade.php
+++ b/resources/views/admin/gallery/index.blade.php
@@ -1,0 +1,74 @@
+<x-admin-layout>
+
+    <div class="w-full h-screen overflow-x-hidden border-t flex flex-col">
+        <main class="w-full flex-grow p-6">
+            <h1 class="w-full text-3xl text-black pb-6">Gallery</h1>
+
+            <div class="w-full mt-12">
+                <p class="text-xl pb-3 flex items-center">
+                    <i class="fas fa-list mr-3"></i> Gallery Records
+                </p>
+                @can('create', App\Models\Gallery::class)
+                    <button class="px-4 py-1 text-white font-light tracking-wider bg-blue-600 rounded mb-2"
+                        onclick="location.href='{{ route('admin.gallery.create') }}';">Add Image</button>
+                @endcan
+                <div class="bg-white overflow-auto">
+                    <table class="text-left w-full border-collapse">
+                        <thead>
+                            <tr>
+                                <th
+                                    class="py-4 px-6 bg-grey-lightest font-bold uppercase text-sm text-grey-dark border-b border-grey-light">
+                                    ID</th>
+                                <th
+                                    class="py-4 px-6 bg-grey-lightest font-bold uppercase text-sm text-grey-dark border-b border-grey-light">
+                                    Title</th>
+                                <th
+                                    class="py-4 px-6 bg-grey-lightest font-bold uppercase text-sm text-grey-dark border-b border-grey-light">
+                                    Service</th>
+                                <th
+                                    class="py-4 px-6 bg-grey-lightest font-bold uppercase text-sm text-grey-dark border-b border-grey-light">
+                                    Image</th>
+                                <th
+                                    class="py-4 px-6 bg-grey-lightest font-bold uppercase text-sm text-grey-dark border-b border-grey-light">
+                                    Manage</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($galleries as $gallery)
+                                <tr class="hover:bg-grey-lighter">
+                                    <td class="py-4 px-6 border-b border-grey-light">{{ $gallery->id }}</td>
+                                    <td class="py-4 px-6 border-b border-grey-light">{{ $gallery->title }}</td>
+                                    <td class="py-4 px-6 border-b border-grey-light">{{ optional($gallery->service)->title ?? '—' }}</td>
+                                    <td class="py-4 px-6 border-b border-grey-light">
+                                        <img src="{{ $gallery->image_url }}" alt="{{ $gallery->title }}" class="h-16 rounded">
+                                    </td>
+                                    <td class="py-4 px-6 border-b border-grey-light">
+                                        @can('update', $gallery)
+                                            <button class="px-4 py-1 text-white font-light tracking-wider bg-green-600 rounded" type="button"
+                                                onclick="location.href='{{ route('admin.gallery.edit', $gallery->id) }}';">Edit</button>
+                                        @endcan
+                                        @can('delete', $gallery)
+                                            <form method="POST" style="display: inline"
+                                                action="{{ route('admin.gallery.destroy', $gallery->id) }}"
+                                                onsubmit="return confirm('Are you sure?')">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button class="px-4 py-1 text-white font-light tracking-wider bg-red-600 rounded"
+                                                    type="submit">Delete</button>
+                                            </form>
+                                        @endcan
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="5" class="py-4 px-6 border-b border-grey-light text-center">No gallery images found.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+                {!! $galleries->links() !!}
+            </div>
+        </main>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/layouts/admin.blade.php
+++ b/resources/views/admin/layouts/admin.blade.php
@@ -95,17 +95,27 @@
                 <i class="fas fa-tag mr-3"></i>
                 Tags
             </a>
-            @can('admin-only')
-                <a href="{{ route('admin.page.index') }}"
-                    class="{{ request()->routeIs('*.page.*') ? 'active-nav-link' : 'opacity-75 hover:opacity-100' }} flex items-center text-white  py-4 pl-6 nav-item">
-                    <i class="far fa-file mr-3"></i>
-                    Pages
-                </a>
-                <a href="{{ route('admin.role.index') }}"
-                    class="{{ request()->routeIs('*.role.*') ? 'active-nav-link' : 'opacity-75 hover:opacity-100' }} flex items-center text-white  py-4 pl-6 nav-item">
-                    <i class="fas fa-user-shield mr-3"></i>
-                    Roles
-                </a>
+                @can('admin-only')
+                    <a href="{{ route('admin.page.index') }}"
+                        class="{{ request()->routeIs('*.page.*') ? 'active-nav-link' : 'opacity-75 hover:opacity-100' }} flex items-center text-white  py-4 pl-6 nav-item">
+                        <i class="far fa-file mr-3"></i>
+                        Pages
+                    </a>
+                    <a href="{{ route('admin.service.index') }}"
+                        class="{{ request()->routeIs('*.service.*') ? 'active-nav-link' : 'opacity-75 hover:opacity-100' }} flex items-center text-white  py-4 pl-6 nav-item">
+                        <i class="fas fa-concierge-bell mr-3"></i>
+                        Services
+                    </a>
+                    <a href="{{ route('admin.gallery.index') }}"
+                        class="{{ request()->routeIs('*.gallery.*') ? 'active-nav-link' : 'opacity-75 hover:opacity-100' }} flex items-center text-white  py-4 pl-6 nav-item">
+                        <i class="fas fa-images mr-3"></i>
+                        Portfolio
+                    </a>
+                    <a href="{{ route('admin.role.index') }}"
+                        class="{{ request()->routeIs('*.role.*') ? 'active-nav-link' : 'opacity-75 hover:opacity-100' }} flex items-center text-white  py-4 pl-6 nav-item">
+                        <i class="fas fa-user-shield mr-3"></i>
+                        Roles
+                    </a>
                 <a href="{{ route('admin.user.index') }}"
                     class="{{ request()->routeIs('*.user.*') ? 'active-nav-link' : 'opacity-75 hover:opacity-100' }} flex items-center text-white  py-4 pl-6 nav-item">
                     <i class="fas fa-users mr-3"></i>
@@ -207,6 +217,16 @@
                         class="flex items-center text-white opacity-75 hover:opacity-100 py-2 pl-4 nav-item">
                         <i class="fas fa-align-left mr-3"></i>
                         Pages
+                    </a>
+                    <a href="{{ route('admin.service.index') }}"
+                        class="flex items-center text-white opacity-75 hover:opacity-100 py-2 pl-4 nav-item">
+                        <i class="fas fa-concierge-bell mr-3"></i>
+                        Services
+                    </a>
+                    <a href="{{ route('admin.gallery.index') }}"
+                        class="flex items-center text-white opacity-75 hover:opacity-100 py-2 pl-4 nav-item">
+                        <i class="fas fa-images mr-3"></i>
+                        Portfolio
                     </a>
                     <a href="{{ route('admin.role.index') }}"
                         class="flex items-center text-white opacity-75 hover:opacity-100 py-2 pl-4 nav-item">

--- a/resources/views/admin/service/create.blade.php
+++ b/resources/views/admin/service/create.blade.php
@@ -1,0 +1,47 @@
+<x-admin-layout>
+
+    <div class="w-full h-screen overflow-x-hidden border-t flex flex-col">
+        <main class="w-full flex-grow p-6">
+            <h1 class="w-full text-3xl text-black pb-6">Add Service</h1>
+
+            <div class="w-full mt-12">
+                <p class="text-xl pb-3 flex items-center">
+                    <i class="fas fa-list mr-3"></i> Service Details
+                </p>
+                <form method="POST" action="{{ route('admin.service.store') }}">
+                    @csrf
+                    <div class="grid gap-6 mb-6 md:grid-cols-2">
+                        <div class="mb-1">
+                            <label for="title" class="block mb-2 text-sm font-medium text-gray-900">Title</label>
+                            <input type="text" id="title" name="title" value="{{ old('title') }}" required
+                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        </div>
+                        <div class="mb-1">
+                            <label for="slug" class="block mb-2 text-sm font-medium text-gray-900">Slug</label>
+                            <input type="text" id="slug" name="slug" value="{{ old('slug') }}"
+                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                                placeholder="leave empty to auto generate">
+                        </div>
+                        <div class="mb-1">
+                            <label for="icon" class="block mb-2 text-sm font-medium text-gray-900">Icon CSS class</label>
+                            <input type="text" id="icon" name="icon" value="{{ old('icon') }}"
+                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                                placeholder="ex: fas fa-code">
+                        </div>
+                        <div class="mb-1">
+                            <label for="order" class="block mb-2 text-sm font-medium text-gray-900">Order</label>
+                            <input type="number" id="order" name="order" min="0" value="{{ old('order', 0) }}"
+                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        </div>
+                    </div>
+                    <div class="mb-4">
+                        <label for="description" class="block mb-2 text-sm font-medium text-gray-900">Description</label>
+                        <textarea id="description" name="description" rows="4"
+                            class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">{{ old('description') }}</textarea>
+                    </div>
+                    <button class="px-4 py-1 text-white font-light tracking-wider bg-blue-600 rounded">Save Service</button>
+                </form>
+            </div>
+        </main>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/service/edit.blade.php
+++ b/resources/views/admin/service/edit.blade.php
@@ -1,0 +1,47 @@
+<x-admin-layout>
+
+    <div class="w-full h-screen overflow-x-hidden border-t flex flex-col">
+        <main class="w-full flex-grow p-6">
+            <h1 class="w-full text-3xl text-black pb-6">Edit Service</h1>
+
+            <div class="w-full mt-12">
+                <p class="text-xl pb-3 flex items-center">
+                    <i class="fas fa-list mr-3"></i> Service Details
+                </p>
+                <form method="POST" action="{{ route('admin.service.update', $service->id) }}">
+                    @csrf
+                    @method('PUT')
+                    <div class="grid gap-6 mb-6 md:grid-cols-2">
+                        <div class="mb-1">
+                            <label for="title" class="block mb-2 text-sm font-medium text-gray-900">Title</label>
+                            <input type="text" id="title" name="title" value="{{ old('title', $service->title) }}" required
+                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        </div>
+                        <div class="mb-1">
+                            <label for="slug" class="block mb-2 text-sm font-medium text-gray-900">Slug</label>
+                            <input type="text" id="slug" name="slug" value="{{ old('slug', $service->slug) }}"
+                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        </div>
+                        <div class="mb-1">
+                            <label for="icon" class="block mb-2 text-sm font-medium text-gray-900">Icon CSS class</label>
+                            <input type="text" id="icon" name="icon" value="{{ old('icon', $service->icon) }}"
+                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        </div>
+                        <div class="mb-1">
+                            <label for="order" class="block mb-2 text-sm font-medium text-gray-900">Order</label>
+                            <input type="number" id="order" name="order" min="0"
+                                value="{{ old('order', $service->order) }}"
+                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        </div>
+                    </div>
+                    <div class="mb-4">
+                        <label for="description" class="block mb-2 text-sm font-medium text-gray-900">Description</label>
+                        <textarea id="description" name="description" rows="4"
+                            class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">{{ old('description', $service->description) }}</textarea>
+                    </div>
+                    <button class="px-4 py-1 text-white font-light tracking-wider bg-blue-600 rounded">Update Service</button>
+                </form>
+            </div>
+        </main>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/service/index.blade.php
+++ b/resources/views/admin/service/index.blade.php
@@ -1,0 +1,76 @@
+<x-admin-layout>
+
+    <div class="w-full h-screen overflow-x-hidden border-t flex flex-col">
+        <main class="w-full flex-grow p-6">
+            <h1 class="w-full text-3xl text-black pb-6">Services</h1>
+
+            <div class="w-full mt-12">
+                <p class="text-xl pb-3 flex items-center">
+                    <i class="fas fa-list mr-3"></i> Services Records
+                </p>
+                @can('create', App\Models\Service::class)
+                    <button class="px-4 py-1 text-white font-light tracking-wider bg-blue-600 rounded mb-2"
+                        onclick="location.href='{{ route('admin.service.create') }}';">Add Service</button>
+                @endcan
+                <div class="bg-white overflow-auto">
+                    <table class="text-left w-full border-collapse">
+                        <thead>
+                            <tr>
+                                <th
+                                    class="py-4 px-6 bg-grey-lightest font-bold uppercase text-sm text-grey-dark border-b border-grey-light">
+                                    ID</th>
+                                <th
+                                    class="py-4 px-6 bg-grey-lightest font-bold uppercase text-sm text-grey-dark border-b border-grey-light">
+                                    Title</th>
+                                <th
+                                    class="py-4 px-6 bg-grey-lightest font-bold uppercase text-sm text-grey-dark border-b border-grey-light">
+                                    Slug</th>
+                                <th
+                                    class="py-4 px-6 bg-grey-lightest font-bold uppercase text-sm text-grey-dark border-b border-grey-light">
+                                    Order</th>
+                                <th
+                                    class="py-4 px-6 bg-grey-lightest font-bold uppercase text-sm text-grey-dark border-b border-grey-light">
+                                    Galleries</th>
+                                <th
+                                    class="py-4 px-6 bg-grey-lightest font-bold uppercase text-sm text-grey-dark border-b border-grey-light">
+                                    Manage</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($services as $service)
+                                <tr class="hover:bg-grey-lighter">
+                                    <td class="py-4 px-6 border-b border-grey-light">{{ $service->id }}</td>
+                                    <td class="py-4 px-6 border-b border-grey-light">{{ $service->title }}</td>
+                                    <td class="py-4 px-6 border-b border-grey-light">{{ $service->slug }}</td>
+                                    <td class="py-4 px-6 border-b border-grey-light">{{ $service->order }}</td>
+                                    <td class="py-4 px-6 border-b border-grey-light">{{ $service->galleries_count }}</td>
+                                    <td class="py-4 px-6 border-b border-grey-light">
+                                        @can('update', $service)
+                                            <button class="px-4 py-1 text-white font-light tracking-wider bg-green-600 rounded" type="button"
+                                                onclick="location.href='{{ route('admin.service.edit', $service->id) }}';">Edit</button>
+                                        @endcan
+                                        @can('delete', $service)
+                                            <form method="POST" style="display: inline"
+                                                action="{{ route('admin.service.destroy', $service->id) }}"
+                                                onsubmit="return confirm('Are you sure?')">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button class="px-4 py-1 text-white font-light tracking-wider bg-red-600 rounded"
+                                                    type="submit">Delete</button>
+                                            </form>
+                                        @endcan
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="6" class="py-4 px-6 border-b border-grey-light text-center">No services found.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+                {!! $services->links() !!}
+            </div>
+        </main>
+    </div>
+</x-admin-layout>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -8,6 +8,8 @@ use App\Http\Controllers\Admin\PageController;
 use App\Http\Controllers\Admin\PostController;
 use App\Http\Controllers\Admin\RoleController;
 use App\Http\Controllers\Admin\SettingController;
+use App\Http\Controllers\Admin\GalleryController;
+use App\Http\Controllers\Admin\ServiceController;
 use App\Http\Controllers\Admin\TagController;
 use App\Http\Controllers\Admin\UserController;
 
@@ -30,5 +32,7 @@ Route::middleware(['auth', 'can:admin-login'])->name('admin.')->prefix('/admin')
         Route::resource('/page', PageController::class);
         Route::resource('/role', RoleController::class, ['only' => ['index']]);
         Route::resource('/setting', SettingController::class, ['only' => ['index', 'update']]);
+        Route::resource('/service', ServiceController::class);
+        Route::resource('/gallery', GalleryController::class);
     });
 });


### PR DESCRIPTION
## Summary
- add database tables for services and galleries with Eloquent models, validation requests and authorization policies
- implement admin resource controllers with image upload handling and register new routes
- build Blade views and navigation updates to manage services and portfolio entries in the admin panel

## Testing
- php artisan test *(fails: vendor/autoload.php missing because composer install cannot run on PHP 8.4)*
- composer install *(fails: dependencies require PHP <= 8.3, container provides PHP 8.4)*

------
https://chatgpt.com/codex/tasks/task_e_68caf3608c4483209493aba1667c70e7