### PR TITLE
Add service and gallery seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ GET | api/posts/{id} | Show Specific Post
 6. Run migrations by executing `php artisan migrate` , Then Run  `php artisan db:seed` if you want use faker database records,
 7. Start the project by running `php artisan serve`
 
+### Demo Data Seeding
+
+Populate the application with ready-to-use demo content (including services and portfolio gallery items) by running:
+
+```
+php artisan db:seed
+```
+
+This command will create the default admin account and fill the main sections of the public site so you can explore the layout without manual data entry.
+
 ### Demo Account
 - AdminURL: http://127.0.0.1:8000/admin
 - Email: admin@example.com

--- a/database/factories/GalleryFactory.php
+++ b/database/factories/GalleryFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Gallery;
+use App\Models\Service;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Gallery>
+ */
+class GalleryFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<\Illuminate\Database\Eloquent\Model>
+     */
+    protected $model = Gallery::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        $title = fake()->sentence(4);
+
+        return [
+            'service_id' => class_exists(Service::class) ? Service::factory() : null,
+            'title' => $title,
+            'description' => fake()->paragraph(),
+            'image' => 'portfolio/' . fake()->uuid() . '.jpg',
+        };
+    }
+}

--- a/database/factories/ServiceFactory.php
+++ b/database/factories/ServiceFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Service;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Service>
+ */
+class ServiceFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<\Illuminate\Database\Eloquent\Model>
+     */
+    protected $model = Service::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        $title = fake()->unique()->sentence(3);
+
+        return [
+            'title' => $title,
+            'description' => fake()->paragraph(3),
+            'icon' => fake()->randomElement([
+                'fa-solid fa-chart-line',
+                'fa-solid fa-lightbulb',
+                'fa-solid fa-shield-halved',
+                'fa-solid fa-users',
+                'fa-solid fa-mobile-screen',
+                'fa-solid fa-gears',
+            ]),
+            'image' => 'services/' . fake()->uuid() . '.jpg',
+        };
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,8 @@
 
 namespace Database\Seeders;
 
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Schema;
 
 class DatabaseSeeder extends Seeder
 {
@@ -25,5 +25,20 @@ class DatabaseSeeder extends Seeder
         \App\Models\Post::factory(50)->create();
         \App\Models\Page::factory(10)->create();
         \App\Models\Tag::factory(10)->create();
+
+        if (
+            class_exists(\App\Models\Service::class)
+            && class_exists(\App\Models\Gallery::class)
+            && Schema::hasTable('services')
+            && Schema::hasTable('galleries')
+        ) {
+            \App\Models\Service::factory(5)
+                ->create()
+                ->each(function ($service) {
+                    \App\Models\Gallery::factory(4)
+                        ->for($service)
+                        ->create();
+                });
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated factories for the Service and Gallery models with realistic demo content
- extend the database seeder to generate featured services with related portfolio items when the tables/models exist
- document how to run the database seeder to preload the new demo data

## Testing
- php artisan test *(fails: vendor/autoload.php missing in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caf366e448832091af6b59e5043c1e