### PR TITLE
Sanitize faker outputs to remove forbidden words

### DIFF
--- a/app/Support/TextSanitizer.php
+++ b/app/Support/TextSanitizer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Str;
+
+class TextSanitizer
+{
+    /**
+     * Words that should be removed from generated lorem text.
+     */
+    protected static array $forbidden = [
+        'sapiente',
+        'non',
+        'sit',
+        'nobis',
+        'officiis',
+        'ut',
+    ];
+
+    /**
+     * Remove the configured forbidden words from the provided text.
+     */
+    public static function removeForbiddenWords(string $text): string
+    {
+        if ($text === '') {
+            return $text;
+        }
+
+        $pattern = '/\\b(' . implode('|', array_map('preg_quote', self::$forbidden)) . ')\\b/i';
+        $cleaned = preg_replace($pattern, '', $text) ?? $text;
+
+        $cleaned = preg_replace('/\s{2,}/', ' ', $cleaned) ?? $cleaned;
+        $cleaned = preg_replace('/\s+([,.;!?])/', '$1', $cleaned) ?? $cleaned;
+
+        return trim($cleaned);
+    }
+
+    /**
+     * Generate sanitized text using the provided generator.
+     */
+    public static function sanitizedFrom(callable $generator, int $attempts = 5, ?string $fallback = null): string
+    {
+        for ($i = 0; $i < $attempts; $i++) {
+            $value = self::removeForbiddenWords((string) $generator());
+
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        $fallbackValue = $fallback ?? 'placeholder-' . Str::random(8);
+
+        return self::removeForbiddenWords($fallbackValue);
+    }
+}

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Support\TextSanitizer;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -16,7 +17,7 @@ class CategoryFactory extends Factory
      */
     public function definition()
     {
-        $name = fake()->unique()->word();
+        $name = TextSanitizer::sanitizedFrom(fn () => fake()->unique()->word());
         $slug = str($name)->slug();
         return [
             'user_id' => rand(1,10),

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Support\TextSanitizer;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -16,12 +17,12 @@ class PageFactory extends Factory
      */
     public function definition()
     {
-        $name = fake()->unique()->word();
+        $name = TextSanitizer::sanitizedFrom(fn () => fake()->unique()->word());
         $slug = str($name)->slug();
         return [
             'user_id' => rand(1,10),
             'name' => $name,
-            'content' => fake()->paragraph(6),
+            'content' => TextSanitizer::sanitizedFrom(fn () => fake()->paragraph(6)),
             'navbar' => fake()->boolean(),
             'footer' => fake()->boolean(),
             'slug' => $slug,

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -2,7 +2,7 @@
 
 namespace Database\Factories;
 
-use Illuminate\Support\Facades\File;
+use App\Support\TextSanitizer;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -19,7 +19,7 @@ class PostFactory extends Factory
      */
     public function definition()
     {
-        $title = fake()->sentence();
+        $title = TextSanitizer::sanitizedFrom(fn () => fake()->sentence());
         $slug = str($title)->slug();
 
 
@@ -27,11 +27,10 @@ class PostFactory extends Factory
             'user_id' => rand(1,10),
             'category_id' => rand(1,5),
             'title' => $title,
-            'content' => fake()->paragraph(6),
+            'content' => TextSanitizer::sanitizedFrom(fn () => fake()->paragraph()),
             'status' => fake()->boolean(),
             'slug' => $slug,
             'image' => null,
-            'content' => fake()->paragraph(),
         ];
     }
 }

--- a/database/factories/SettingFactory.php
+++ b/database/factories/SettingFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Support\TextSanitizer;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -17,11 +18,11 @@ class SettingFactory extends Factory
     public function definition()
     {
         return [
-            'site_name' => fake()->word(),
+            'site_name' => TextSanitizer::sanitizedFrom(fn () => fake()->word()),
             'contact_email' => fake()->email(),
-            'description' => fake()->sentence(),
-            'about' => fake()->paragraph(1),
-            'copy_rights' => fake()->sentence(),
+            'description' => TextSanitizer::sanitizedFrom(fn () => fake()->sentence()),
+            'about' => TextSanitizer::sanitizedFrom(fn () => fake()->paragraph(1)),
+            'copy_rights' => TextSanitizer::sanitizedFrom(fn () => fake()->sentence()),
             'url_fb' => fake()->url(),
             'url_twitter' => fake()->url(),
             'url_insta' => fake()->url(),

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Support\TextSanitizer;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -17,7 +18,7 @@ class TagFactory extends Factory
     public function definition()
     {
         return [
-            'name' => fake()->unique()->word(),
+            'name' => TextSanitizer::sanitizedFrom(fn () => fake()->unique()->word()),
         ];
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable TextSanitizer helper that strips forbidden lorem words
- apply the sanitizer across post, page, category, tag, and setting factories to prevent the words from being seeded

## Testing
- php artisan test *(fails: missing vendor/autoload.php because dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0383b1c883209cd2c7f59bae4bc1