### PR TITLE
Fix gallery page to use stored images

### DIFF
--- a/app/Http/Controllers/Front/GalleryController.php
+++ b/app/Http/Controllers/Front/GalleryController.php
@@ -3,13 +3,15 @@
 namespace App\Http\Controllers\Front;
 
 use App\Http\Controllers\Controller;
+use App\Models\Gallery;
 
 class GalleryController extends Controller
 {
     public function index()
     {
-        $images = config('institutional.gallery');
+        $galleries = Gallery::query()->with('service:id,title')->latest()->get();
+        $highlights = $galleries->take(4);
 
-        return view('front.gallery', compact('images'));
+        return view('front.gallery', compact('galleries', 'highlights'));
     }
 }

--- a/resources/views/front/gallery.blade.php
+++ b/resources/views/front/gallery.blade.php
@@ -11,32 +11,52 @@
 
     <section class="py-16">
         <div class="container mx-auto px-6">
-            <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
-                @foreach ($images as $item)
-                    <figure class="group bg-white rounded-2xl overflow-hidden shadow-sm border border-gray-100">
-                        <img src="{{ $item['image'] }}" alt="{{ $item['caption'] }}" class="h-64 w-full object-cover transition duration-500 group-hover:scale-105">
-                        <figcaption class="p-6 text-gray-700 text-center font-medium">{{ $item['caption'] }}</figcaption>
-                    </figure>
-                @endforeach
-            </div>
+            @if ($galleries->isEmpty())
+                <p class="text-center text-gray-500 text-lg">Ainda não existem imagens na galeria. Volte em breve para conhecer os nossos projetos.</p>
+            @else
+                <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+                    @foreach ($galleries as $gallery)
+                        @php
+                            $subtitle = $gallery->description ?: optional($gallery->service)->title;
+                        @endphp
+                        <figure class="group bg-white rounded-2xl overflow-hidden shadow-sm border border-gray-100">
+                            <img src="{{ $gallery->image_url }}" alt="{{ $gallery->title ?? 'Imagem da galeria' }}" class="h-64 w-full object-cover transition duration-500 group-hover:scale-105">
+                            <figcaption class="p-6 text-gray-700 text-center">
+                                <span class="block font-semibold text-gray-900">{{ $gallery->title }}</span>
+                                @if ($subtitle)
+                                    <span class="mt-2 block text-sm text-gray-600">{{ $subtitle }}</span>
+                                @endif
+                            </figcaption>
+                        </figure>
+                    @endforeach
+                </div>
+            @endif
         </div>
     </section>
 
-    <section class="py-16 bg-blue-50">
-        <div class="container mx-auto px-6 grid gap-10 lg:grid-cols-2 lg:items-center">
-            <div class="space-y-6">
-                <h2 class="text-3xl font-bold text-gray-900">Rigor em todas as fases</h2>
-                <p class="text-gray-600">As nossas equipas acompanham a execução no terreno com metodologias ágeis e ferramentas digitais que garantem o cumprimento de prazos e padrões de qualidade.</p>
-                <a href="{{ route('services') }}" class="inline-flex items-center text-blue-700 font-semibold hover:text-blue-900">Conhecer serviços →</a>
+    @if ($highlights->isNotEmpty())
+        <section class="py-16 bg-blue-50">
+            <div class="container mx-auto px-6 grid gap-10 lg:grid-cols-2 lg:items-center">
+                <div class="space-y-6">
+                    <h2 class="text-3xl font-bold text-gray-900">Rigor em todas as fases</h2>
+                    <p class="text-gray-600">As nossas equipas acompanham a execução no terreno com metodologias ágeis e ferramentas digitais que garantem o cumprimento de prazos e padrões de qualidade.</p>
+                    <a href="{{ route('services') }}" class="inline-flex items-center text-blue-700 font-semibold hover:text-blue-900">Conhecer serviços →</a>
+                </div>
+                <div class="grid gap-6 sm:grid-cols-2">
+                    @foreach ($highlights as $highlight)
+                        @php
+                            $subtitle = $highlight->description ?: optional($highlight->service)->title;
+                        @endphp
+                        <div class="bg-white border border-gray-200 rounded-xl p-4 shadow-sm">
+                            <img src="{{ $highlight->image_url }}" alt="{{ $highlight->title ?? 'Imagem da galeria' }}" class="h-32 w-full object-cover rounded-lg">
+                            <p class="mt-3 text-sm text-gray-700 font-medium">{{ $highlight->title }}</p>
+                            @if ($subtitle)
+                                <p class="text-xs text-gray-500">{{ \Illuminate\Support\Str::limit($subtitle, 80) }}</p>
+                            @endif
+                        </div>
+                    @endforeach
+                </div>
             </div>
-            <div class="grid gap-6 sm:grid-cols-2">
-                @foreach (array_slice($images, 0, 4) as $item)
-                    <div class="bg-white border border-gray-200 rounded-xl p-4 shadow-sm">
-                        <img src="{{ $item['image'] }}" alt="{{ $item['caption'] }}" class="h-32 w-full object-cover rounded-lg">
-                        <p class="mt-3 text-sm text-gray-600">{{ $item['caption'] }}</p>
-                    </div>
-                @endforeach
-            </div>
-        </div>
-    </section>
+        </section>
+    @endif
 </x-blog-layout>


### PR DESCRIPTION
## Summary
- load gallery entries from the database in the front-facing gallery controller and share highlight items
- render gallery and highlight sections with stored image data, including empty states when no records exist

## Testing
- php artisan test *(fails: missing vendor dependencies because PHP 8.4 is unsupported by locked packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1940c63c8320a20accdb56cb63af