### PR TITLE
Fix gallery image URLs for public storage

### DIFF
--- a/app/Http/Controllers/Admin/GalleryController.php
+++ b/app/Http/Controllers/Admin/GalleryController.php
@@ -44,7 +44,7 @@ class GalleryController extends Controller
         $data = $request->validated();
 
         if ($request->hasFile('image')) {
-            $data['image_path'] = $request->file('image')->store('images/galleries');
+            $data['image_path'] = $request->file('image')->store('images/galleries', 'public');
         }
 
         unset($data['image']);
@@ -72,7 +72,7 @@ class GalleryController extends Controller
         $data = $request->validated();
 
         if ($request->hasFile('image')) {
-            $data['image_path'] = $request->file('image')->store('images/galleries');
+            $data['image_path'] = $request->file('image')->store('images/galleries', 'public');
         }
 
         unset($data['image']);

--- a/app/Models/Gallery.php
+++ b/app/Models/Gallery.php
@@ -49,7 +49,9 @@ class Gallery extends Model
      */
     public function getImageUrlAttribute(): string
     {
-        return $this->image_path ? asset("storage/{$this->image_path}") : asset('import/assets/post-pic-dummy.png');
+        return $this->image_path
+            ? Storage::disk('public')->url($this->image_path)
+            : asset('import/assets/post-pic-dummy.png');
     }
 
     /**
@@ -59,13 +61,13 @@ class Gallery extends Model
     {
         static::updating(function (Gallery $gallery): void {
             if ($gallery->isDirty('image_path') && !is_null($gallery->getRawOriginal('image_path'))) {
-                Storage::delete($gallery->getRawOriginal('image_path'));
+                Storage::disk('public')->delete($gallery->getRawOriginal('image_path'));
             }
         });
 
         static::deleting(function (Gallery $gallery): void {
             if (!is_null($gallery->getRawOriginal('image_path'))) {
-                Storage::delete($gallery->getRawOriginal('image_path'));
+                Storage::disk('public')->delete($gallery->getRawOriginal('image_path'));
             }
         });
     }


### PR DESCRIPTION
## Summary
- store uploaded gallery images on the public disk so they are web-accessible
- generate image URLs and cleanup using the public storage disk helper

## Testing
- php artisan test *(fails: vendor dependencies require PHP <= 8.3; container runs PHP 8.4)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1e7341448320960a9ddc585d02dc