### PR TITLE
Handle gallery image URLs from multiple sources

### DIFF
--- a/app/Models/Gallery.php
+++ b/app/Models/Gallery.php
@@ -59,7 +59,20 @@ class Gallery extends Model
             return $path;
         }
 
-        $normalizedPath = ltrim($path, '/');
+        $normalizedPath = str_replace('\\', '/', $path);
+        $normalizedPath = ltrim($normalizedPath, '/');
+
+        $prefixesToStrip = [
+            'public/',
+            'storage/public/',
+            'storage/app/public/',
+        ];
+
+        foreach ($prefixesToStrip as $prefix) {
+            if (str_starts_with($normalizedPath, $prefix)) {
+                $normalizedPath = substr($normalizedPath, strlen($prefix));
+            }
+        }
 
         if (str_starts_with($normalizedPath, 'storage/')) {
             $publicPath = public_path($normalizedPath);
@@ -76,6 +89,11 @@ class Gallery extends Model
 
         if (file_exists(public_path($normalizedPath))) {
             return asset($normalizedPath);
+        }
+
+        $publicStoragePath = 'storage/' . ltrim($normalizedPath, '/');
+        if (file_exists(public_path($publicStoragePath))) {
+            return asset($publicStoragePath);
         }
 
         return asset('import/assets/post-pic-dummy.png');

--- a/app/Models/Gallery.php
+++ b/app/Models/Gallery.php
@@ -49,20 +49,33 @@ class Gallery extends Model
      */
     public function getImageUrlAttribute(): string
     {
-        if (is_null($this->image_path) || $this->image_path === '') {
+        $path = $this->image_path;
+
+        if (is_null($path) || $path === '') {
             return asset('import/assets/post-pic-dummy.png');
         }
 
-        if (filter_var($this->image_path, FILTER_VALIDATE_URL)) {
-            return $this->image_path;
+        if (filter_var($path, FILTER_VALIDATE_URL)) {
+            return $path;
         }
 
-        if (Storage::disk('public')->exists($this->image_path)) {
-            return Storage::disk('public')->url($this->image_path);
+        $normalizedPath = ltrim($path, '/');
+
+        if (str_starts_with($normalizedPath, 'storage/')) {
+            $publicPath = public_path($normalizedPath);
+            if (file_exists($publicPath)) {
+                return asset($normalizedPath);
+            }
+
+            $normalizedPath = ltrim(substr($normalizedPath, strlen('storage/')), '/');
         }
 
-        if (file_exists(public_path($this->image_path))) {
-            return asset($this->image_path);
+        if (Storage::disk('public')->exists($normalizedPath)) {
+            return Storage::disk('public')->url($normalizedPath);
+        }
+
+        if (file_exists(public_path($normalizedPath))) {
+            return asset($normalizedPath);
         }
 
         return asset('import/assets/post-pic-dummy.png');

--- a/app/Models/Gallery.php
+++ b/app/Models/Gallery.php
@@ -49,9 +49,23 @@ class Gallery extends Model
      */
     public function getImageUrlAttribute(): string
     {
-        return $this->image_path
-            ? Storage::disk('public')->url($this->image_path)
-            : asset('import/assets/post-pic-dummy.png');
+        if (is_null($this->image_path) || $this->image_path === '') {
+            return asset('import/assets/post-pic-dummy.png');
+        }
+
+        if (filter_var($this->image_path, FILTER_VALIDATE_URL)) {
+            return $this->image_path;
+        }
+
+        if (Storage::disk('public')->exists($this->image_path)) {
+            return Storage::disk('public')->url($this->image_path);
+        }
+
+        if (file_exists(public_path($this->image_path))) {
+            return asset($this->image_path);
+        }
+
+        return asset('import/assets/post-pic-dummy.png');
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure gallery images render even when stored on different disks or remote URLs
- fall back to bundled placeholder when no accessible image path is available

## Testing
- `php artisan test` *(fails: missing vendor directory because composer install requires PHP <= 8.3)*

------
https://chatgpt.com/codex/tasks/task_e_68cb20170d4c832098efd3ab144fa7e7